### PR TITLE
feat: constant-time Kronecker delta

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ merlin = { version = "3.0.0", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }
 serde = { version = "1.0.193", optional = true, default-features = false, features = ["alloc", "derive"] }
 snafu = { version = "0.7.5", default-features = false }
+subtle = { version = "2.5.0", default-features = false, features = ["core_hint_black_box"] }
 zeroize = { version = "1.7.0", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -14,6 +14,7 @@ use rand_core::CryptoRngCore;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use snafu::prelude::*;
+use subtle::{ConditionallySelectable, ConstantTimeEq};
 use zeroize::Zeroizing;
 
 use crate::{statement::Statement, util::DangerousRng, witness::Witness};
@@ -49,13 +50,11 @@ pub enum ProofError {
     InvalidChallenge,
 }
 
-/// Kronecker delta function with scalar output.
+/// Constant-time Kronecker delta function with scalar output.
 fn delta(x: u32, y: u32) -> Scalar {
-    if x == y {
-        Scalar::ONE
-    } else {
-        Scalar::ZERO
-    }
+    let mut result = Scalar::ZERO;
+    result.conditional_assign(&Scalar::ONE, x.ct_eq(&y));
+    result
 }
 
 /// Get nonzero powers of a challenge value from a transcript.


### PR DESCRIPTION
As noted in the documentation, the implementation does not make any particular guarantees about proving operations being constant time with respect to witness index values. This PR takes a step forward by using `subtle` to make the Kronecker delta run in constant time.