### PR TITLE
feat!: make the verifier deterministic

### DIFF
--- a/benches/triptych.rs
+++ b/benches/triptych.rs
@@ -105,7 +105,7 @@ fn verify_proof(c: &mut Criterion) {
 
                 // Start the benchmark
                 b.iter(|| {
-                    assert!(proof.verify(&statement, Some(message), &mut rng));
+                    assert!(proof.verify(&statement, Some(message)));
                 })
             });
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,11 +98,11 @@
 //! let proof = Proof::prove(&witness, &statement, Some(message), &mut rng).unwrap();
 //!
 //! // The proof should verify against the statement and message
-//! assert!(proof.verify(&statement, Some(message), &mut rng));
+//! assert!(proof.verify(&statement, Some(message)));
 //!
 //! // The proof should not verify against a different message
 //! let evil_message = "Pure evil".as_bytes();
-//! assert!(!proof.verify(&statement, Some(evil_message), &mut rng));
+//! assert!(!proof.verify(&statement, Some(evil_message)));
 //! ```
 
 #![no_std]

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -64,10 +64,13 @@ struct Weights {
 impl Weights {
     /// Generate a set of weights from a proof.
     #[allow(non_snake_case)]
-    fn from_proof(proof: &Proof) -> Self {
-        // Hash the proof elements
+    fn generate(statement: &Statement, proof: &Proof) -> Self {
+        // Hash the parameteres, statement, and proof elements
         let mut hasher = Hasher::new();
         hasher.update("Triptych Weights".as_bytes());
+        hasher.update(statement.get_params().get_hash());
+        hasher.update(statement.get_input_set().get_hash());
+        hasher.update(statement.get_J().compress().as_bytes());
         hasher.update(proof.A.compress().as_bytes());
         hasher.update(proof.B.compress().as_bytes());
         hasher.update(proof.C.compress().as_bytes());
@@ -401,7 +404,7 @@ impl Proof {
             .collect::<Vec<Vec<Scalar>>>();
 
         // Generate weights for verification equations
-        let weights = Weights::from_proof(self);
+        let weights = Weights::generate(statement, self);
         let w1 = weights.w1;
         let w2 = weights.w2;
         let w4 = weights.w4;


### PR DESCRIPTION
As noted in #6, verification requires a suitable random number generator, which the target may not be able to provide. The generator is used to produce weights that are applied to each verification equation for efficiency.

This PR makes the verifier deterministic by deriving the weights from a hash of the parameters, statement, and proof elements. This means the prover cannot modify these without changing the weights, making it infeasible to produce an invalid proof that passes verification.

BREAKING CHANGE: Changes the public API by removing the requirement that the verifier supply a random number generator.