### PR TITLE
feat: add `std` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ rand = { version = "0.8.5", default-features = false, features = ["getrandom"] }
 rand_chacha = { version = "0.3.1", default-features = false }
 
 [features]
-serde = ["dep:serde", "curve25519-dalek/serde"]
+serde = ["dep:serde", "curve25519-dalek/serde", "zeroize/serde"]
+std = ["blake3/std", "merlin/std", "rand_core/std", "serde?/std", "snafu/std", "zeroize/std"]
 
 [[bench]]
 name = "triptych"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
 //!
 //! The implementation keeps dependencies to a minimum, and is `no_std` right out of the box.
 //! You can enable the optional `serde` feature for proof (de)serialization support.
+//! You can enable the optional `std` feature for corresponding dependency features.
 //!
 //! # Security
 //!


### PR DESCRIPTION
This PR adds an optional `std` feature that enables corresponding dependency features on targets that support this.