### PR TITLE
feat!: make the verifier deterministic

### DIFF
--- a/benches/triptych.rs
+++ b/benches/triptych.rs
@@ -105,7 +105,7 @@ fn verify_proof(c: &mut Criterion) {
 
                 // Start the benchmark
                 b.iter(|| {
-                    assert!(proof.verify(&statement, Some(message), &mut rng));
+                    assert!(proof.verify(&statement, Some(message)));
                 })
             });
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,11 +99,11 @@
 //! let proof = Proof::prove(&witness, &statement, Some(message), &mut rng).unwrap();
 //!
 //! // The proof should verify against the statement and message
-//! assert!(proof.verify(&statement, Some(message), &mut rng));
+//! assert!(proof.verify(&statement, Some(message)));
 //!
 //! // The proof should not verify against a different message
 //! let evil_message = "Pure evil".as_bytes();
-//! assert!(!proof.verify(&statement, Some(evil_message), &mut rng));
+//! assert!(!proof.verify(&statement, Some(evil_message)));
 //! ```
 
 #![no_std]
@@ -116,5 +116,7 @@ pub mod parameters;
 pub mod proof;
 /// Triptych proof statements.
 pub mod statement;
+/// Various utility functionality.
+pub(crate) mod util;
 /// Triptych proof witnesses.
 pub mod witness;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,29 @@
+use rand_core::{
+    impls::{next_u32_via_fill, next_u64_via_fill},
+    CryptoRng,
+    RngCore,
+};
+
+/// A "null" random number generator that exists only for deterministic transcript-based weight generation.
+/// This is DANGEROUS in general, and you almost certainly should not use it elsewhere!
+pub(crate) struct DangerousRng;
+
+impl RngCore for DangerousRng {
+    #[allow(unused_variables)]
+    fn fill_bytes(&mut self, dest: &mut [u8]) {}
+
+    #[allow(unused_variables)]
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+        Ok(())
+    }
+
+    fn next_u32(&mut self) -> u32 {
+        next_u32_via_fill(self)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        next_u64_via_fill(self)
+    }
+}
+
+impl CryptoRng for DangerousRng {}


### PR DESCRIPTION
As noted in #6, verification requires a suitable random number generator, which the target may not be able to provide. The generator is used to produce weights that are applied to each verification equation for efficiency.

This PR makes the verifier deterministic by deriving the weights from a pseudorandom number generator derived from the proof transcript after adding the prover responses to it. This means the prover cannot modify the proof without changing the weights, making it infeasible to produce an invalid proof that passes verification.

Closes #6.

Supersedes #8.

BREAKING CHANGE: Changes the public API by removing the requirement that the verifier supply a random number generator.