### PR TITLE
chore: add optional `std` feature to `subtle`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rand_chacha = { version = "0.3.1", default-features = false }
 
 [features]
 serde = ["dep:serde", "curve25519-dalek/serde", "zeroize/serde"]
-std = ["blake3/std", "merlin/std", "rand_core/std", "serde?/std", "snafu/std", "zeroize/std"]
+std = ["blake3/std", "merlin/std", "rand_core/std", "serde?/std", "snafu/std", "subtle/std", "zeroize/std"]
 
 [[bench]]
 name = "triptych"


### PR DESCRIPTION
Recent work in #9 adds an optional `std` feature that enables this feature in dependencies. This was not enabled with the change in #4 that adds the `subtle` dependency.

This PR updates the feature accordingly.