### PR TITLE
docs: add information about `std` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ It's possible to generalize these if done safely, but the implementation doesn't
 
 The implementation keeps dependencies to a minimum, and is `no_std` right out of the box.
 You can enable the optional `serde` feature for proof (de)serialization support.
+You can enable the optional `std` feature for corresponding dependency features.
 
 ## Security
 


### PR DESCRIPTION
Recent work in #9 adds an optional `std` feature. This PR adds relevant documentation.