### PR TITLE
feat!: move proof message into statement

### DIFF
--- a/benches/triptych.rs
+++ b/benches/triptych.rs
@@ -54,13 +54,13 @@ fn generate_proof(c: &mut Criterion) {
 
                 // Generate statement
                 let J = witness.compute_linking_tag();
-                let statement = Statement::new(&params, &input_set, &J).unwrap();
+                let message = "Proof message".as_bytes();
+                let statement = Statement::new(&params, &input_set, &J, Some(message)).unwrap();
 
                 // Start the benchmark
                 b.iter(|| {
                     // Generate the proof
-                    let _proof =
-                        Proof::prove(&witness, &statement, Some("Proof message".as_bytes()), &mut rng).unwrap();
+                    let _proof = Proof::prove(&witness, &statement, &mut rng).unwrap();
                 })
             });
         }
@@ -103,13 +103,13 @@ fn generate_proof_vartime(c: &mut Criterion) {
 
                 // Generate statement
                 let J = witness.compute_linking_tag();
-                let statement = Statement::new(&params, &input_set, &J).unwrap();
+                let message = "Proof message".as_bytes();
+                let statement = Statement::new(&params, &input_set, &J, Some(message)).unwrap();
 
                 // Start the benchmark
                 b.iter(|| {
                     // Generate the proof
-                    let _proof =
-                        Proof::prove_vartime(&witness, &statement, Some("Proof message".as_bytes()), &mut rng).unwrap();
+                    let _proof = Proof::prove_vartime(&witness, &statement, &mut rng).unwrap();
                 })
             });
         }
@@ -147,14 +147,14 @@ fn verify_proof(c: &mut Criterion) {
 
                 // Generate statement
                 let J = witness.compute_linking_tag();
-                let statement = Statement::new(&params, &input_set, &J).unwrap();
-
                 let message = "Proof message".as_bytes();
-                let proof = Proof::prove(&witness, &statement, Some(message), &mut rng).unwrap();
+                let statement = Statement::new(&params, &input_set, &J, Some(message)).unwrap();
+
+                let proof = Proof::prove(&witness, &statement, &mut rng).unwrap();
 
                 // Start the benchmark
                 b.iter(|| {
-                    assert!(proof.verify(&statement, Some(message)));
+                    assert!(proof.verify(&statement));
                 })
             });
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,22 +88,16 @@
 //!     .collect::<Vec<RistrettoPoint>>();
 //! let input_set = Arc::new(InputSet::new(&M));
 //!
-//! // Generate the statement, which includes the verification key vector and linking tag
+//! // Generate the statement, which includes the verification key vector, linking tag, and optional message
 //! let J = witness.compute_linking_tag();
-//! let statement = Statement::new(&params, &input_set, &J).unwrap();
-//!
-//! // We can optionally specify an arbitrary message to bind into the proof
 //! let message = "This message will be bound to the proof".as_bytes();
+//! let statement = Statement::new(&params, &input_set, &J, Some(message)).unwrap();
 //!
 //! // Generate a proof from the witness
-//! let proof = Proof::prove(&witness, &statement, Some(message), &mut rng).unwrap();
+//! let proof = Proof::prove(&witness, &statement, &mut rng).unwrap();
 //!
-//! // The proof should verify against the statement and message
-//! assert!(proof.verify(&statement, Some(message)));
-//!
-//! // The proof should not verify against a different message
-//! let evil_message = "Pure evil".as_bytes();
-//! assert!(!proof.verify(&statement, Some(evil_message)));
+//! // The proof should verify against the same statement
+//! assert!(proof.verify(&statement));
 //! ```
 
 #![no_std]

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -50,7 +50,8 @@ impl InputSet {
 
 /// A Triptych proof statement.
 ///
-/// The statement consists of an input set of verification keys and a linking tag.
+/// The statement consists of an input set of verification keys, a linking tag, and an optional message.
+/// If provided, the message is bound to any proof generated using the statement.
 /// It also contains parameters that, among other things, enforce the size of the input set.
 #[allow(non_snake_case)]
 #[derive(Clone, Eq, PartialEq)]
@@ -58,6 +59,7 @@ pub struct Statement {
     params: Arc<Parameters>,
     input_set: Arc<InputSet>,
     J: RistrettoPoint,
+    message: Option<Vec<u8>>,
 }
 
 /// Errors that can arise relating to `Statement`.
@@ -75,12 +77,14 @@ impl Statement {
     /// parameters `params`, and which does not contain the identity group element.
     /// If either of these conditions is not met, returns an error.
     ///
+    /// If provided, the optional `message` will be bound to any proof generated using the resulting statement.
     /// The linking tag `J` is assumed to have been computed from witness data or otherwise provided externally.
     #[allow(non_snake_case)]
     pub fn new(
         params: &Arc<Parameters>,
         input_set: &Arc<InputSet>,
         J: &RistrettoPoint,
+        message: Option<&[u8]>,
     ) -> Result<Self, StatementError> {
         // Check that the input vector is valid against the parameters
         if input_set.get_keys().len() != params.get_N() as usize {
@@ -94,6 +98,7 @@ impl Statement {
             params: params.clone(),
             input_set: input_set.clone(),
             J: *J,
+            message: message.map(|m| m.to_vec()),
         })
     }
 
@@ -111,5 +116,13 @@ impl Statement {
     #[allow(non_snake_case)]
     pub fn get_J(&self) -> &RistrettoPoint {
         &self.J
+    }
+
+    /// Get the message for this statement
+    pub fn get_message(&self) -> Option<&[u8]> {
+        match &self.message {
+            Some(message) => Some(message.as_slice()),
+            None => None,
+        }
     }
 }


### PR DESCRIPTION
This PR moves the optional proof message into the statement. This cleans up the API and will make it easier to eventually implement batch verification (see #21).

BREAKING CHANGE: Updates the API for proofs and statements.