### PR TITLE
feat: batch verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Successful verification of a signature means that the signer knew the signing ke
 It also produces a linking tag; if any two verified signatures have the same linking tag, they were produced using the same signing key.
 However, it is not possible to determine the signing key associated to a linking tag, nor the corresponding verification key.
 
+Triptych proofs scale nicely, with their size increasingly only logarithmically with the size of the verification key set. Proofs sharing the same verification key set can also be verified efficiently in batches to save time.
+
 More formally, let `G` and `U` be fixed independent generators of the Ristretto group.
 Let `N = n**m`, where `n, m > 1` are fixed parameters.
 The Triptych proving system protocol is a sigma protocol for the following relation, where `M` is an `N`-vector of group elements:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,9 @@
 //! the same linking tag, they were produced using the same signing key. However, it is not possible to determine the
 //! signing key associated to a linking tag, nor the corresponding verification key.
 //!
+//! Triptych proofs scale nicely, with their size increasingly only logarithmically with the size of the verification
+//! key set. Proofs sharing the same verification key set can also be verified efficiently in batches to save time.
+//!
 //! More formally, let `G` and `U` be fixed independent generators of the Ristretto group.
 //! Let `N = n**m`, where `n, m > 1` are fixed parameters.
 //! The Triptych proving system protocol is a sigma protocol for the following relation, where `M` is an `N`-vector of
@@ -50,7 +53,8 @@
 //!
 //! # Example
 //!
-//! Here's a complete example of how to generate and verify a Triptych proof.
+//! Here's a complete example of how to generate and verify a Triptych proof; see the documentation for additional
+//! functionality.
 //!
 //! ```
 //! # extern crate alloc;


### PR DESCRIPTION
This PR adds batch verification functionality, where multiple proofs sharing a common input set can be efficiently verified together. This is done internally by adding a new `Proof::verify_batch` that accepts statement and proof slices, checks their consistency, and then goes to work. To keep the API cleaner, the existing `verify` functionality becomes a trivial wrapper. This doesn't result in any efficiency hit for the single-proof case, but provides significant benefits for nontrivial batching.

It also adds a simple test and benchmarks.

Closes #21.