### PR TITLE
feat!: add transcript composition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["cryptography"]
 [dependencies]
 blake3 = { version = "1.5.0", default-features = false }
 curve25519-dalek = { version = "4.1.1", default-features = false, features = ["alloc", "digest", "rand_core", "zeroize"] }
+itertools = { version = "0.12.0", default-features = false, features = ["use_alloc"] }
 merlin = { version = "3.0.0", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }
 serde = { version = "1.0.193", optional = true, default-features = false, features = ["alloc", "derive"] }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The Triptych proving system protocol is a sigma protocol for the following relat
 
 `{ M, J ; (l, r) : M[l] = r*G, r*J = U }`
 
-It's possible to use the Fiat-Shamir transformation to produce a non-interactive protocol that can additionally bind an arbitrary message into the proof.
+It's possible to use the Fiat-Shamir transformation to produce a non-interactive protocol that can additionally bind an arbitrary message into the transcript.
 This produces the linkable ring signature.
 
 ## Implementation notes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //! `{ M, J ; (l, r) : M[l] = r*G, r*J = U }`
 //!
 //! It's possible to use the Fiat-Shamir transformation to produce a non-interactive protocol that can additionally bind
-//! an arbitrary message into the proof. This produces the linkable ring signature.
+//! an arbitrary message into the transcript. This produces the linkable ring signature.
 //!
 //! # Implementation notes
 //!
@@ -54,6 +54,7 @@
 //!
 //! # use triptych::parameters::Parameters;
 //! use curve25519_dalek::RistrettoPoint;
+//! use merlin::Transcript;
 //! use rand_core::OsRng;
 //! # use triptych::statement::InputSet;
 //! # use triptych::statement::Statement;
@@ -84,16 +85,19 @@
 //!     .collect::<Vec<RistrettoPoint>>();
 //! let input_set = Arc::new(InputSet::new(&M));
 //!
-//! // Generate the statement, which includes the verification key vector, linking tag, and optional message
+//! // Generate the statement, which includes the verification key vector and linking tag
 //! let J = witness.compute_linking_tag();
 //! let message = "This message will be bound to the proof".as_bytes();
-//! let statement = Statement::new(&params, &input_set, &J, Some(message)).unwrap();
+//! let statement = Statement::new(&params, &input_set, &J).unwrap();
+//!
+//! // Generate a transcript
+//! let mut transcript = Transcript::new("Test transcript".as_bytes());
 //!
 //! // Generate a proof from the witness
-//! let proof = Proof::prove(&witness, &statement, &mut rng).unwrap();
+//! let proof = Proof::prove(&witness, &statement, &mut rng, &mut transcript.clone()).unwrap();
 //!
-//! // The proof should verify against the same statement
-//! assert!(proof.verify(&statement));
+//! // The proof should verify against the same statement and transcript
+//! assert!(proof.verify(&statement, &mut transcript));
 //! ```
 
 #![no_std]

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -50,8 +50,7 @@ impl InputSet {
 
 /// A Triptych proof statement.
 ///
-/// The statement consists of an input set of verification keys, a linking tag, and an optional message.
-/// If provided, the message is bound to any proof generated using the statement.
+/// The statement consists of an input set of verification keys and a linking tag.
 /// It also contains parameters that, among other things, enforce the size of the input set.
 #[allow(non_snake_case)]
 #[derive(Clone, Eq, PartialEq)]
@@ -59,7 +58,6 @@ pub struct Statement {
     params: Arc<Parameters>,
     input_set: Arc<InputSet>,
     J: RistrettoPoint,
-    message: Option<Vec<u8>>,
 }
 
 /// Errors that can arise relating to `Statement`.
@@ -77,14 +75,12 @@ impl Statement {
     /// parameters `params`, and which does not contain the identity group element.
     /// If either of these conditions is not met, returns an error.
     ///
-    /// If provided, the optional `message` will be bound to any proof generated using the resulting statement.
     /// The linking tag `J` is assumed to have been computed from witness data or otherwise provided externally.
     #[allow(non_snake_case)]
     pub fn new(
         params: &Arc<Parameters>,
         input_set: &Arc<InputSet>,
         J: &RistrettoPoint,
-        message: Option<&[u8]>,
     ) -> Result<Self, StatementError> {
         // Check that the input vector is valid against the parameters
         if input_set.get_keys().len() != params.get_N() as usize {
@@ -98,7 +94,6 @@ impl Statement {
             params: params.clone(),
             input_set: input_set.clone(),
             J: *J,
-            message: message.map(|m| m.to_vec()),
         })
     }
 
@@ -116,13 +111,5 @@ impl Statement {
     #[allow(non_snake_case)]
     pub fn get_J(&self) -> &RistrettoPoint {
         &self.J
-    }
-
-    /// Get the message for this statement
-    pub fn get_message(&self) -> Option<&[u8]> {
-        match &self.message {
-            Some(message) => Some(message.as_slice()),
-            None => None,
-        }
     }
 }


### PR DESCRIPTION
This PR adds transcript composition, which allows for Triptych proofs to be more seamlessly used as part of larger protocols. To do so, the API is modified such that the prover and verifier accept a mutable Merlin transcript. This replaces the existing message binding, which is offloaded to the transcript.

Closes #28.

BREAKING CHANGE: Updates the APIs for `Statement` and `Proof`.