### PR TITLE
test: fix batch verification benchmark

### DIFF
--- a/benches/triptych.rs
+++ b/benches/triptych.rs
@@ -189,7 +189,7 @@ fn verify_batch_proof(c: &mut Criterion) {
                 );
                 group.bench_function(&label, |b| {
                     // Generate data
-                    let (witnesses, statements, transcripts) = generate_data(&params, 1, &mut rng);
+                    let (witnesses, statements, transcripts) = generate_data(&params, batch, &mut rng);
 
                     // Generate the proofs
                     let proofs = izip!(witnesses.iter(), statements.iter(), transcripts.clone().iter_mut())


### PR DESCRIPTION
The benchmark for batch verification always runs against a single proof due to a typo. This PR fixes the error.