### PR TITLE
chore: ensure placeholder RNG is deterministic

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -3,6 +3,7 @@ use rand_core::{
     CryptoRng,
     RngCore,
 };
+use zeroize::Zeroize;
 
 /// A "null" random number generator that exists only for deterministic transcript-based weight generation.
 /// This is DANGEROUS in general, and you almost certainly should not use it elsewhere!
@@ -10,10 +11,14 @@ pub(crate) struct DangerousRng;
 
 impl RngCore for DangerousRng {
     #[allow(unused_variables)]
-    fn fill_bytes(&mut self, dest: &mut [u8]) {}
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        dest.zeroize();
+    }
 
     #[allow(unused_variables)]
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+        self.fill_bytes(dest);
+
         Ok(())
     }
 


### PR DESCRIPTION
Verifier random weights are generated using a `TranscripRng` built from an extended transcript of each proof in a batch. Because this requires an externally-provided random number generator, we include a placeholder `DangerousRng` that effectively does nothing except satisfy API requirements.

When generating "random" values via mutable buffer references, `DangerousRng` leaves the buffer alone, which could result in non-deterministic behavior. This isn't problematic, but has a bad code smell. This PR updates `DangerousRng` so it zeroizes buffers to make its behavior deterministic.