### PR TITLE
chore!: rename functions

### DIFF
--- a/benches/triptych.rs
+++ b/benches/triptych.rs
@@ -95,7 +95,7 @@ fn generate_proof(c: &mut Criterion) {
                     || transcripts[0].clone(),
                     |t| {
                         // Generate the proof
-                        Proof::prove(&witnesses[0], &statements[0], &mut rng, t).unwrap();
+                        Proof::prove_with_rng(&witnesses[0], &statements[0], &mut rng, t).unwrap();
                     },
                     BatchSize::SmallInput,
                 )
@@ -131,7 +131,7 @@ fn generate_proof_vartime(c: &mut Criterion) {
                     || transcripts[0].clone(),
                     |t| {
                         // Generate the proof
-                        Proof::prove_vartime(&witnesses[0], &statements[0], &mut rng, t).unwrap();
+                        Proof::prove_with_rng_vartime(&witnesses[0], &statements[0], &mut rng, t).unwrap();
                     },
                     BatchSize::SmallInput,
                 )
@@ -158,7 +158,8 @@ fn verify_proof(c: &mut Criterion) {
                 let (witnesses, statements, transcripts) = generate_data(&params, 1, &mut rng);
 
                 // Generate the proof
-                let proof = Proof::prove(&witnesses[0], &statements[0], &mut rng, &mut transcripts[0].clone()).unwrap();
+                let proof = Proof::prove_with_rng(&witnesses[0], &statements[0], &mut rng, &mut transcripts[0].clone())
+                    .unwrap();
 
                 // Start the benchmark
                 b.iter_batched_ref(
@@ -200,7 +201,7 @@ fn verify_batch_proof(c: &mut Criterion) {
 
                     // Generate the proofs
                     let proofs = izip!(witnesses.iter(), statements.iter(), transcripts.clone().iter_mut())
-                        .map(|(w, s, t)| Proof::prove_vartime(w, s, &mut rng, t).unwrap())
+                        .map(|(w, s, t)| Proof::prove_with_rng_vartime(w, s, &mut rng, t).unwrap())
                         .collect::<Vec<Proof>>();
 
                     // Start the benchmark

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,8 @@
 //! functionality.
 //!
 //! ```
+//! # #[cfg(feature = "rand")]
+//! # {
 //! # extern crate alloc;
 //! use alloc::sync::Arc;
 //!
@@ -95,10 +97,11 @@
 //! let mut transcript = Transcript::new("Test transcript".as_bytes());
 //!
 //! // Generate a proof from the witness
-//! let proof = Proof::prove(&witness, &statement, &mut rng, &mut transcript.clone()).unwrap();
+//! let proof = Proof::prove(&witness, &statement, &mut transcript.clone()).unwrap();
 //!
 //! // The proof should verify against the same statement and transcript
 //! assert!(proof.verify(&statement, &mut transcript));
+//! # }
 //! ```
 
 #![no_std]


### PR DESCRIPTION
Recent work in #38 adds prover functionality that uses `OsRng` instead of requiring the caller to supply a random number generator. The intent was to maintain API compatibility, but this resulted in function names that are opposite what you might expect.

This PR renames the prover functions. The `prove` and `prove_vartime` functions require the `rand` feature and use `OsRng`. The `prove_with_rng` and `prove_with_rng_vartime` functions require the caller to supply a random number generator.

BREAKING CHANGE: This changes the API by renaming functions.