### PR TITLE
test: add WASM build to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
       - name: Release build (no features)
         run: cargo build --release --all-targets --no-default-features
-      - name: Release (all features)
+      - name: Release build (all features)
         run: cargo build --release --all-targets --all-features
+      - name: Release build (WASM)
+        run: cargo build --release --target wasm32-unknown-unknown --no-default-features
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR adds a `wasm32-unknown-unknown` target build to the CI pipeline.