### PR TITLE
docs: update documentation for backend selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ There are several features that are enabled by default:
 - `serde`: adds proof serialization and deserialization
 - `std`: adds corresponding dependency features
 
+The underlying [curve library](https://crates.io/crates/curve25519-dalek) chooses an arithmetic backend based on CPU feature detection.
+Using a nightly compiler broadens the backend set, and may provide better performance.
+You can examine performance using the benchmarks: either `cargo bench` or `cargo +nightly bench`.
+
 ## Warning
 
 While this implementation is written with security in mind, it is currently **experimental** and not suitable for production use.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,10 @@
 //! - `serde`: adds proof serialization and deserialization
 //! - `std`: adds corresponding dependency features
 //!
+//! The underlying [curve library](https://crates.io/crates/curve25519-dalek) chooses an arithmetic backend based on CPU feature detection.
+//! Using a nightly compiler broadens the backend set, and may provide better performance.
+//! You can examine performance using the benchmarks: either `cargo bench` or `cargo +nightly bench`.
+//!
 //! # Warning
 //!
 //! While this implementation is written with security in mind, it is currently **experimental** and not suitable for


### PR DESCRIPTION
The underlying curve library chooses an arithmetic backend based on CPU feature selection, and can see improved performance on a nightly compiler. This PR adds information about this to the documentation.