### PR TITLE
feat: custom serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,15 @@ The implementation keeps dependencies to a minimum, and is `no_std` friendly.
 
 There are several features that are enabled by default:
 - `rand`: adds additional prover functionality that supplies a cryptographically-secure random number generator
-- `serde`: adds proof serialization and deserialization
+- `serde`: adds proof serialization and deserialization via `serde`
 - `std`: adds corresponding dependency features
 
 The underlying [curve library](https://crates.io/crates/curve25519-dalek) chooses an arithmetic backend based on CPU feature detection.
 Using a nightly compiler broadens the backend set, and may provide better performance.
 You can examine performance using the benchmarks: either `cargo bench` or `cargo +nightly bench`.
+
+Proofs support a custom serialization format designed to be efficient and canonical.
+This functionality has an associated fuzzer that can be run using a nightly compiler: `cargo +nightly fuzz run proofs`
 
 ## Warning
 

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "triptych_fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.triptych]
+path = ".."
+
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "proofs"
+path = "fuzz_targets/proofs.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/proofs.rs
+++ b/fuzz/fuzz_targets/proofs.rs
@@ -1,0 +1,16 @@
+// Copyright (c) 2024, The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use triptych::proof::Proof;
+
+// Test basic deserialization and canonical serialization
+fuzz_target!(|data: &[u8]| {
+	// If deserialization succeeds, serialization should be canonical
+	if let Ok(proof) = Proof::from_bytes(data) {
+		assert_eq!(&proof.to_bytes(), data);
+	}
+});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,12 +36,16 @@
 //!
 //! There are several features that are enabled by default:
 //! - `rand`: adds additional prover functionality that supplies a cryptographically-secure random number generator
-//! - `serde`: adds proof serialization and deserialization
+//! - `serde`: adds proof serialization and deserialization via `serde`
 //! - `std`: adds corresponding dependency features
 //!
 //! The underlying [curve library](https://crates.io/crates/curve25519-dalek) chooses an arithmetic backend based on CPU feature detection.
 //! Using a nightly compiler broadens the backend set, and may provide better performance.
 //! You can examine performance using the benchmarks: either `cargo bench` or `cargo +nightly bench`.
+//!
+//! Proofs support a custom serialization format designed to be efficient and canonical.
+//! This functionality has an associated fuzzer that can be run using a nightly compiler: `cargo +nightly fuzz run
+//! proofs`
 //!
 //! # Warning
 //!


### PR DESCRIPTION
Serialization using `serde` is suboptimal. Depending on the encoding used, serialization may not be canonical, and is likely to be inefficient due to length encoding.

This PR adds custom serialization and deserialization that is efficient and canonical.

Because this is easy to mess up, it also adds a basic fuzzer. The fuzzer attempts to deserialize byte slices; deserialization should either fail or subsequently serialize canonically.

Note that `serde`-based serialization is still supported.

Closes #43.