### PR TITLE
chore: add `use_std` feature for `itertools`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rand_core = { version = "0.6.4", default-features = false, features = ["getrando
 default = ["rand", "serde", "std"]
 rand = ["rand_core/getrandom"]
 serde = ["dep:serde", "curve25519-dalek/serde", "zeroize/serde"]
-std = ["blake3/std", "merlin/std", "rand_core/std", "serde?/std", "snafu/std", "subtle/std", "zeroize/std"]
+std = ["blake3/std", "itertools/use_std", "merlin/std", "rand_core/std", "serde?/std", "snafu/std", "subtle/std", "zeroize/std"]
 
 [[bench]]
 name = "triptych"


### PR DESCRIPTION
This PR enables the `use_std` feature for `iterools` when the `std` feature is enabled. This was not done in #30 when the dependency was added.