### PR TITLE
feat: add constant-time index decomposition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["cryptography"]
 
 [dependencies]
 blake3 = { version = "1.5.0", default-features = false }
+crypto-bigint = { version = "0.5.5", default-features = false }
 curve25519-dalek = { version = "4.1.1", default-features = false, features = ["alloc", "digest", "rand_core", "zeroize"] }
 itertools = { version = "0.12.0", default-features = false }
 merlin = { version = "3.0.0", default-features = false }

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -227,8 +227,11 @@ impl Proof {
 
         // Compute the `B` matrix commitment
         let r_B = Scalar::random(&mut transcript_rng);
-        let l_decomposed =
-            GrayIterator::decompose(params.get_n(), params.get_m(), l).ok_or(ProofError::InvalidParameter)?;
+        let l_decomposed = if vartime {
+            GrayIterator::decompose_vartime(params.get_n(), params.get_m(), l).ok_or(ProofError::InvalidParameter)?
+        } else {
+            GrayIterator::decompose(params.get_n(), params.get_m(), l).ok_or(ProofError::InvalidParameter)?
+        };
         let sigma = (0..params.get_m())
             .map(|j| {
                 (0..params.get_n())


### PR DESCRIPTION
This PR adds a Gray decomposition function that runs in constant time. This is useful since decomposition of the signing index currently uses modular reduction and division operations that do not run in constant time.

The functionality is accomplished in a somewhat kludgy manner using `crypto-bigint`, which represents its `Uint` types internally using target-specific word sizes. To ensure we support 32-bit targets, we use a single-limb `Uint<1>` type to represent the index and modulus for Gray decomposition; this limb wraps [a 32-bit word](https://github.com/RustCrypto/crypto-bigint/blob/e925f370995da5ca519db482906aff4679656c4a/src/limb.rs#L36-L38) on 32-bit targets, and [a 64-bit word](https://github.com/RustCrypto/crypto-bigint/blob/e925f370995da5ca519db482906aff4679656c4a/src/limb.rs#L48-L50) on 64-bit targets. Once we complete the required decomposition operations in constant time, we reach into the `Uint<1>` limb and extract the word, converting to a `u32` in a target-dependent manner.

It would be nice if there were an easier way to support constant-time operations with a `U32` type supplied by the library in a way that allowed for cleanly extracting the underlying `u32`, but this is not the case.

The Triptych prover and verifier each iterate over all possible Gray-decomposed indexes, while the prover additionally decomposes the signing index separately. For this reason, we keep the existing variable-time decomposition functionality as `GrayIterator::decompose_vartime`, and support the new constant-time functionality as `GrayIterator::decompose`. When constructing a `GrayIterator` for iteration, the variable-time functionality is chosen. This keeps things speedy in the case when no secret data is being used.

Closes #5.