### PR TITLE
docs: update documentation for nightly compiler warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ There are several features that are enabled by default:
 
 The underlying [curve library](https://crates.io/crates/curve25519-dalek) chooses an arithmetic backend based on CPU feature detection.
 Using a nightly compiler broadens the backend set, and may provide better performance.
-You can examine performance using the benchmarks: either `cargo bench` or `cargo +nightly bench`.
+Note that nightly compilers after `nightly-2024-02-04` will [not work](https://github.com/dalek-cryptography/curve25519-dalek/issues/618).
+You can examine performance using the benchmarks: either `cargo bench` or `cargo +nightly-2024-02-04 bench`.
 
 Proofs support a custom serialization format designed to be efficient and canonical.
-This functionality has an associated fuzzer that can be run using a nightly compiler: `cargo +nightly fuzz run proofs`
+This functionality has an associated fuzzer that can be run using a nightly compiler: `cargo +nightly-2024-02-04 fuzz run proofs`
 
 ## Warning
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,11 +41,12 @@
 //!
 //! The underlying [curve library](https://crates.io/crates/curve25519-dalek) chooses an arithmetic backend based on CPU feature detection.
 //! Using a nightly compiler broadens the backend set, and may provide better performance.
-//! You can examine performance using the benchmarks: either `cargo bench` or `cargo +nightly bench`.
+//! Note that nightly compilers after `nightly-2024-02-04` will [not work](https://github.com/dalek-cryptography/curve25519-dalek/issues/618).
+//! You can examine performance using the benchmarks: either `cargo bench` or `cargo +nightly-2024-02-04 bench`.
 //!
 //! Proofs support a custom serialization format designed to be efficient and canonical.
-//! This functionality has an associated fuzzer that can be run using a nightly compiler: `cargo +nightly fuzz run
-//! proofs`
+//! This functionality has an associated fuzzer that can be run using a nightly compiler: `cargo +nightly-2024-02-04
+//! fuzz run proofs`
 //!
 //! # Warning
 //!


### PR DESCRIPTION
An [issue](https://github.com/dalek-cryptography/curve25519-dalek/issues/618) with the curve library means nightly compilers after `nightly-2024-02-04` will not work. The documentation currently references the latest nightly compiler for benchmarks and fuzzing; this PR adds a warning and updates the relevant commands.