### PR TITLE
docs: remove unused message from example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,6 @@
 //!
 //! // Generate the statement, which includes the verification key vector and linking tag
 //! let J = witness.compute_linking_tag();
-//! let message = "This message will be bound to the proof".as_bytes();
 //! let statement = Statement::new(&params, &input_set, &J).unwrap();
 //!
 //! // Generate a transcript


### PR DESCRIPTION
The documentation example defines a message that is never used, as this functionality was changed in #30. This PR removes it.