### PR TITLE
ci: additional CI target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown, thumbv8m.main-none-eabi
       - name: Release build (no features)
         run: cargo build --release --all-targets --no-default-features
       - name: Release build (all features)
         run: cargo build --release --all-targets --all-features
       - name: Release build (WASM)
         run: cargo build --release --target wasm32-unknown-unknown --no-default-features
+      - name: Release build (metal)
+        run: cargo build --release --target thumbv8m.main-none-eabi --no-default-features
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR adds `thumbv8m.main-none-eabi` as an additional CI build target for improved `no_std` checks.