### PR TITLE
chore: update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ categories = ["cryptography"]
 [dependencies]
 blake3 = { version = "1.5.0", default-features = false }
 crypto-bigint = { version = "0.5.5", default-features = false }
-curve25519-dalek = { version = "4.1.1", default-features = false, features = ["alloc", "digest", "rand_core", "zeroize"] }
-itertools = { version = "0.12.0", default-features = false }
+curve25519-dalek = { version = "4.1.2", default-features = false, features = ["alloc", "digest", "rand_core", "zeroize"] }
+itertools = { version = "0.12.1", default-features = false }
 merlin = { version = "3.0.0", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }
-serde = { version = "1.0.195", optional = true, default-features = false, features = ["derive"] }
+serde = { version = "1.0.196", optional = true, default-features = false, features = ["derive"] }
 snafu = { version = "0.8.0", default-features = false }
 subtle = { version = "2.5.0", default-features = false, features = ["core_hint_black_box"] }
 zeroize = { version = "1.7.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -37,11 +37,10 @@ There are several features that are enabled by default:
 
 The underlying [curve library](https://crates.io/crates/curve25519-dalek) chooses an arithmetic backend based on CPU feature detection.
 Using a nightly compiler broadens the backend set, and may provide better performance.
-Note that nightly compilers after `nightly-2024-02-04` will [not work](https://github.com/dalek-cryptography/curve25519-dalek/issues/618).
-You can examine performance using the benchmarks: either `cargo bench` or `cargo +nightly-2024-02-04 bench`.
+You can examine performance using the benchmarks: either `cargo bench` or `cargo +nightly bench`.
 
 Proofs support a custom serialization format designed to be efficient and canonical.
-This functionality has an associated fuzzer that can be run using a nightly compiler: `cargo +nightly-2024-02-04 fuzz run proofs`.
+This functionality has an associated fuzzer that can be run using a nightly compiler: `cargo +nightly fuzz run proofs`.
 
 ## Warning
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,12 +41,11 @@
 //!
 //! The underlying [curve library](https://crates.io/crates/curve25519-dalek) chooses an arithmetic backend based on CPU feature detection.
 //! Using a nightly compiler broadens the backend set, and may provide better performance.
-//! Note that nightly compilers after `nightly-2024-02-04` will [not work](https://github.com/dalek-cryptography/curve25519-dalek/issues/618).
-//! You can examine performance using the benchmarks: either `cargo bench` or `cargo +nightly-2024-02-04 bench`.
+//! You can examine performance using the benchmarks: either `cargo bench` or `cargo +nightly bench`.
 //!
 //! Proofs support a custom serialization format designed to be efficient and canonical.
-//! This functionality has an associated fuzzer that can be run using a nightly compiler: `cargo +nightly-2024-02-04
-//! fuzz run proofs`.
+//! This functionality has an associated fuzzer that can be run using a nightly compiler: `cargo +nightly fuzz run
+//! proofs`.
 //!
 //! # Warning
 //!


### PR DESCRIPTION
This PR updates dependencies to keep everything fresh, allowing us to remove the nightly compiler warning introduced in #50.