### PR TITLE
nit: use byte strings

### DIFF
--- a/benches/triptych.rs
+++ b/benches/triptych.rs
@@ -65,8 +65,8 @@ fn generate_data<R: CryptoRngCore>(
     // Generate transcripts
     let transcripts = (0..b)
         .map(|i| {
-            let mut transcript = Transcript::new("Test transcript".as_bytes());
-            transcript.append_u64("index".as_bytes(), i as u64);
+            let mut transcript = Transcript::new(b"Test transcript");
+            transcript.append_u64(b"index", i as u64);
 
             transcript
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@
 //! let statement = Statement::new(&params, &input_set, &J).unwrap();
 //!
 //! // Generate a transcript
-//! let mut transcript = Transcript::new("Test transcript".as_bytes());
+//! let mut transcript = Transcript::new(b"Test transcript");
 //!
 //! // Generate a proof from the witness
 //! let proof = Proof::prove(&witness, &statement, &mut transcript.clone()).unwrap();

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -59,7 +59,7 @@ impl Parameters {
         // Use `BLAKE3` to generate `U`
         let mut U_bytes = [0u8; 64];
         let mut hasher = Hasher::new();
-        hasher.update("Triptych U".as_bytes());
+        hasher.update(b"Triptych U");
         hasher.finalize_xof().fill(&mut U_bytes);
         let U = RistrettoPoint::from_uniform_bytes(&U_bytes);
 
@@ -92,13 +92,13 @@ impl Parameters {
         // Use `BLAKE3` to generate `CommitmentH`
         let mut CommitmentH_bytes = [0u8; 64];
         let mut hasher = Hasher::new();
-        hasher.update("Triptych CommitmentH".as_bytes());
+        hasher.update(b"Triptych CommitmentH");
         hasher.finalize_xof().fill(&mut CommitmentH_bytes);
         let CommitmentH = RistrettoPoint::from_uniform_bytes(&CommitmentH_bytes);
 
         // Use `BLAKE3` for the commitment matrix generators
         let mut hasher = Hasher::new();
-        hasher.update("Triptych CommitmentG".as_bytes());
+        hasher.update(b"Triptych CommitmentG");
         hasher.update(&n.to_le_bytes());
         hasher.update(&m.to_le_bytes());
         let mut hasher_xof = hasher.finalize_xof();
@@ -112,7 +112,7 @@ impl Parameters {
 
         // Use `BLAKE3` for the transcript hash
         let mut hasher = Hasher::new();
-        hasher.update("Triptych Parameters".as_bytes());
+        hasher.update(b"Triptych Parameters");
         hasher.update(&Self::VERSION.to_le_bytes());
         hasher.update(&n.to_le_bytes());
         hasher.update(&m.to_le_bytes());

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -484,7 +484,7 @@ impl Proof {
         let mut U_scalar = Scalar::ZERO;
 
         // Set up a transcript generator for use in weighting
-        let mut transcript_weights = Transcript::new("Triptych verifier weights".as_bytes());
+        let mut transcript_weights = Transcript::new(b"Triptych verifier weights");
 
         let mut null_rng = NullRng;
 
@@ -499,7 +499,7 @@ impl Proof {
 
             // Run the Fiat-Shamir response phase to get the transcript generator and weight
             let mut transcript_rng = transcript.response(&proof.f, &proof.z_A, &proof.z_C, &proof.z);
-            transcript_weights.append_u64("proof".as_bytes(), transcript_rng.as_rngcore().next_u64());
+            transcript_weights.append_u64(b"proof", transcript_rng.as_rngcore().next_u64());
         }
 
         // Finalize the weighting transcript into a pseudorandom number generator
@@ -846,8 +846,8 @@ mod test {
         // Generate transcripts
         let transcripts = (0..b)
             .map(|i| {
-                let mut transcript = Transcript::new("Test transcript".as_bytes());
-                transcript.append_u64("index".as_bytes(), i as u64);
+                let mut transcript = Transcript::new(b"Test transcript");
+                transcript.append_u64(b"index", i as u64);
 
                 transcript
             })
@@ -975,7 +975,7 @@ mod test {
             Proof::prove_with_rng_vartime(&witnesses[0], &statements[0], &mut rng, &mut transcripts[0]).unwrap();
 
         // Generate a modified transcript
-        let mut evil_transcript = Transcript::new("Evil transcript".as_bytes());
+        let mut evil_transcript = Transcript::new(b"Evil transcript");
 
         // Attempt to verify the proof against the new statement, which should fail
         assert!(proof.verify(&statements[0], &mut evil_transcript).is_err());

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -29,7 +29,7 @@ impl InputSet {
     pub fn new(M: &[RistrettoPoint]) -> Self {
         // Use `BLAKE3` for the transcript hash
         let mut hasher = Hasher::new();
-        hasher.update("Triptych InputSet".as_bytes());
+        hasher.update(b"Triptych InputSet");
         hasher.update(&Self::VERSION.to_le_bytes());
         for item in M {
             hasher.update(item.compress().as_bytes());

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -80,7 +80,7 @@ impl<'a, R: CryptoRngCore> ProofTranscript<'a, R> {
 
         // Get the initial challenge using wide reduction
         let mut xi_bytes = [0u8; 64];
-        self.transcript.challenge_bytes("xi".as_bytes(), &mut xi_bytes);
+        self.transcript.challenge_bytes(b"xi", &mut xi_bytes);
         let xi = Scalar::from_bytes_mod_order_wide(&xi_bytes);
 
         // Get powers of the challenge and confirm they are nonzero


### PR DESCRIPTION
This PR switches from `"string".as_bytes()` to `b"string"` for consistency and conciseness.