### PR TITLE
chore: remove `subtle` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ merlin = { version = "3.0.0", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }
 serde = { version = "1.0.196", optional = true, default-features = false, features = ["derive"] }
 snafu = { version = "0.8.0", default-features = false }
-subtle = { version = "2.5.0", default-features = false, features = ["core_hint_black_box"] }
+subtle = { version = "2.5.0", default-features = false }
 zeroize = { version = "1.7.0", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
We currently use the `core_hint_black_box` feature from `subtle`, which uses a particular [optimization barrier](https://github.com/dalek-cryptography/subtle/blob/6b6a81ad9a6a00c0b42c327eaf4b2f785774377e/src/lib.rs#L245-L250).

However, the standard library [documentation](https://doc.rust-lang.org/std/hint/fn.black_box.html) cautions against the use of `std::hint::black_box` for cryptographic use. This has led `subtle` to [remove it](https://github.com/dalek-cryptography/subtle/pull/107) in an upcoming release, at which point the feature will do nothing.

This PR takes the proactive step of removing the feature. There is still an [optimization barrier](https://github.com/dalek-cryptography/subtle/blob/6b6a81ad9a6a00c0b42c327eaf4b2f785774377e/src/lib.rs#L227-L243) in place, which will become the default after the feature is deprecated.
