### PR TITLE
feat: use precomputation on input set keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["cryptography"]
 blake3 = { version = "1.5.1", default-features = false }
 crypto-bigint = { version = "0.5.5", default-features = false }
 curve25519-dalek = { version = "4.1.3", default-features = false, features = ["alloc", "digest", "rand_core", "zeroize"] }
+derivative = { version = "2.2.0", default-features = false, features = ["use_core"] }
 itertools = { version = "0.12.1", default-features = false }
 merlin = { version = "3.0.0", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }


### PR DESCRIPTION
The curve library supports precomputation, which allows us to evaluate multiscalar multiplication operations using both [fixed and dynamic values](https://docs.rs/curve25519-dalek/latest/curve25519_dalek/traits/trait.VartimePrecomputedMultiscalarMul.html#method.vartime_mixed_multiscalar_mul). This means we can generate precomputation tables for input set keys in advance, and use them when generating and verifying proofs.

This PR adds such functionality. However, it surprisingly results in no efficiency benefit (and possibly even an efficiency regression); this is unclear and could use some digging.

Keeping this open as a draft in case a solution is found.