### PR TITLE
feat: allow for variable-time Kronecker delta

### DIFF
--- a/src/proof.rs
+++ b/src/proof.rs
@@ -229,7 +229,7 @@ impl Proof {
         let sigma = (0..params.get_m())
             .map(|j| {
                 (0..params.get_n())
-                    .map(|i| delta(l_decomposed[j as usize], i))
+                    .map(|i| delta(l_decomposed[j as usize], i, timing))
                     .collect::<Vec<Scalar>>()
             })
             .collect::<Vec<Vec<Scalar>>>();


### PR DESCRIPTION
The library supports both constant- and variable-time proving, depending on the caller's needs. However, the Kronecker delta function supported only constant-time operations. This PR adds a variable-time option for efficiency. It also adds unit tests for the function.