### PR TITLE
chore: update exports

### DIFF
--- a/benches/triptych.rs
+++ b/benches/triptych.rs
@@ -12,7 +12,6 @@ use alloc::sync::Arc;
 use criterion::{BatchSize, Criterion};
 use curve25519_dalek::{RistrettoPoint, Scalar};
 use itertools::izip;
-use merlin::Transcript;
 use rand_chacha::ChaCha12Rng;
 use rand_core::{CryptoRngCore, SeedableRng};
 use triptych::{
@@ -20,6 +19,7 @@ use triptych::{
     proof::Proof,
     statement::{InputSet, Statement},
     witness::Witness,
+    Transcript,
 };
 
 // Parameters

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,6 @@
 //! use alloc::sync::Arc;
 //!
 //! use curve25519_dalek::RistrettoPoint;
-//! use merlin::Transcript;
 //! use rand_core::OsRng;
 //! use triptych::*;
 //!
@@ -110,6 +109,8 @@
 #![no_std]
 
 extern crate alloc;
+
+pub use merlin::Transcript;
 
 /// Iterated arbitrary-base Gray code functionaity.
 pub(crate) mod gray;

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -11,7 +11,6 @@ use curve25519_dalek::{
     Scalar,
 };
 use itertools::{izip, Itertools};
-use merlin::Transcript;
 use rand_core::CryptoRngCore;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -21,10 +20,11 @@ use zeroize::Zeroizing;
 
 use crate::{
     gray::GrayIterator,
-    statement::Statement,
     transcript::ProofTranscript,
     util::{delta, NullRng, OperationTiming},
-    witness::Witness,
+    Statement,
+    Transcript,
+    Witness,
 };
 
 // Size of serialized proof elements in bytes
@@ -920,15 +920,17 @@ mod test {
 
     use curve25519_dalek::{traits::Identity, RistrettoPoint, Scalar};
     use itertools::izip;
-    use merlin::Transcript;
     use rand_chacha::ChaCha12Rng;
     use rand_core::{CryptoRngCore, SeedableRng};
 
     use crate::{
-        parameters::Parameters,
-        proof::{Proof, ProofError, SERIALIZED_BYTES},
-        statement::{InputSet, Statement},
-        witness::Witness,
+        proof::{ProofError, SERIALIZED_BYTES},
+        InputSet,
+        Parameters,
+        Proof,
+        Statement,
+        Transcript,
+        Witness,
     };
 
     // Check that the serialized proof element size constant is correct

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -7,7 +7,7 @@ use blake3::Hasher;
 use curve25519_dalek::{traits::Identity, RistrettoPoint};
 use snafu::prelude::*;
 
-use crate::parameters::Parameters;
+use crate::Parameters;
 
 /// A Triptych input set.
 ///
@@ -150,7 +150,7 @@ mod test {
     use rand_chacha::ChaCha12Rng;
     use rand_core::SeedableRng;
 
-    use crate::{parameters::Parameters, statement::InputSet};
+    use crate::{InputSet, Parameters};
 
     // Helper function to generate random vectors
     fn random_vector(size: usize) -> Vec<RistrettoPoint> {

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -4,10 +4,10 @@
 use alloc::vec::Vec;
 
 use curve25519_dalek::{RistrettoPoint, Scalar};
-use merlin::{Transcript, TranscriptRng};
+use merlin::TranscriptRng;
 use rand_core::CryptoRngCore;
 
-use crate::{proof::ProofError, Parameters, Statement, Witness};
+use crate::{proof::ProofError, Parameters, Statement, Transcript, Witness};
 
 // Version identifier
 const VERSION: u64 = 0;

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -8,7 +8,7 @@ use rand_core::CryptoRngCore;
 use snafu::prelude::*;
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
-use crate::parameters::Parameters;
+use crate::Parameters;
 
 /// A Triptych proof witness.
 ///


### PR DESCRIPTION
This PR exports `merlin::Transcript` for easier implementation, and updates the use of other exports within the codebase for consistency.