### PR TITLE
test: update and fix fuzzing

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -24,3 +24,9 @@ name = "proofs"
 path = "fuzz_targets/proofs.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "parallel"
+path = "fuzz_targets/parallel.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/parallel.rs
+++ b/fuzz/fuzz_targets/parallel.rs
@@ -5,7 +5,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use triptych::proof::TriptychProof;
+use triptych::parallel::proof::TriptychProof;
 
 // Test basic deserialization and canonical serialization
 fuzz_target!(|data: &[u8]| {


### PR DESCRIPTION
Fuzzing broke due to the API change in #78. This PR includes a fix for this, and also adds fuzzing for parallel proofs as introduced in #79.