### PR TITLE
fix: mitigate transcript collision

### DIFF
--- a/benches/parallel.rs
+++ b/benches/parallel.rs
@@ -63,7 +63,7 @@ fn generate_data<R: CryptoRngCore>(
         offsets.push(r_offset * params.get_H());
         M1[witness.get_l() as usize] = witness.compute_auxiliary_verification_key() + offsets.last().unwrap();
     }
-    let input_set = Arc::new(TriptychInputSet::new(&M, &M1));
+    let input_set = Arc::new(TriptychInputSet::new(&M, &M1).unwrap());
 
     // Generate statements
     let mut statements = Vec::with_capacity(b);

--- a/benches/triptych.rs
+++ b/benches/triptych.rs
@@ -53,7 +53,7 @@ fn generate_data<R: CryptoRngCore>(
     for witness in &witnesses {
         M[witness.get_l() as usize] = witness.compute_verification_key();
     }
-    let input_set = Arc::new(TriptychInputSet::new(&M));
+    let input_set = Arc::new(TriptychInputSet::new(&M).unwrap());
 
     // Generate statements
     let mut statements = Vec::with_capacity(b);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@
 //!         }
 //!     })
 //!     .collect::<Vec<RistrettoPoint>>();
-//! let input_set = Arc::new(TriptychInputSet::new(&M));
+//! let input_set = Arc::new(TriptychInputSet::new(&M).unwrap());
 //!
 //! // Generate the statement, which includes the verification key vector and linking tag
 //! let J = witness.compute_linking_tag();

--- a/src/parallel/mod.rs
+++ b/src/parallel/mod.rs
@@ -63,7 +63,7 @@
 //!         }
 //!     })
 //!     .collect::<Vec<RistrettoPoint>>();
-//! let input_set = Arc::new(TriptychInputSet::new(&M, &M1));
+//! let input_set = Arc::new(TriptychInputSet::new(&M, &M1).unwrap());
 //!
 //! // Generate the statement, which includes the verification key vectors and linking tag
 //! let J = witness.compute_linking_tag();

--- a/src/parallel/proof.rs
+++ b/src/parallel/proof.rs
@@ -1071,7 +1071,7 @@ mod test {
             offsets.push(r_offset * params.get_H());
             M1[witness.get_l() as usize] = witness.compute_auxiliary_verification_key() + offsets.last().unwrap();
         }
-        let input_set = Arc::new(TriptychInputSet::new(&M, &M1));
+        let input_set = Arc::new(TriptychInputSet::new(&M, &M1).unwrap());
 
         // Generate statements
         let mut statements = Vec::with_capacity(b);
@@ -1332,7 +1332,7 @@ mod test {
         let M1 = statements[0].get_input_set().get_auxiliary_keys().to_vec();
         let index = ((witnesses[0].get_l() + 1) % witnesses[0].get_params().get_N()) as usize;
         M[index] = RistrettoPoint::random(&mut rng);
-        let evil_input_set = Arc::new(TriptychInputSet::new(&M, &M1));
+        let evil_input_set = Arc::new(TriptychInputSet::new(&M, &M1).unwrap());
         let evil_statement = TriptychStatement::new(
             statements[0].get_params(),
             &evil_input_set,
@@ -1364,7 +1364,7 @@ mod test {
         let mut M1 = statements[0].get_input_set().get_auxiliary_keys().to_vec();
         let index = ((witnesses[0].get_l() + 1) % witnesses[0].get_params().get_N()) as usize;
         M1[index] = RistrettoPoint::random(&mut rng);
-        let evil_input_set = Arc::new(TriptychInputSet::new(&M, &M1));
+        let evil_input_set = Arc::new(TriptychInputSet::new(&M, &M1).unwrap());
         let evil_statement = TriptychStatement::new(
             statements[0].get_params(),
             &evil_input_set,

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -979,7 +979,7 @@ mod test {
         for witness in &witnesses {
             M[witness.get_l() as usize] = witness.compute_verification_key();
         }
-        let input_set = Arc::new(TriptychInputSet::new(&M));
+        let input_set = Arc::new(TriptychInputSet::new(&M).unwrap());
 
         // Generate statements
         let mut statements = Vec::with_capacity(b);
@@ -1239,7 +1239,7 @@ mod test {
         let mut M = statements[0].get_input_set().get_keys().to_vec();
         let index = ((witnesses[0].get_l() + 1) % witnesses[0].get_params().get_N()) as usize;
         M[index] = RistrettoPoint::random(&mut rng);
-        let evil_input_set = Arc::new(TriptychInputSet::new(&M));
+        let evil_input_set = Arc::new(TriptychInputSet::new(&M).unwrap());
         let evil_statement =
             TriptychStatement::new(statements[0].get_params(), &evil_input_set, statements[0].get_J()).unwrap();
 


### PR DESCRIPTION
When using input set padding, the padded set is used in transcript operations. This means there is a possibility of transcript collision. This PR mitigates the issue by including the unpadded length in proof transcripts.

Closes #83.