### PR TITLE
feat: use Merlin transcripts for component hashing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,8 @@ extern crate alloc;
 
 pub use merlin::Transcript;
 
+pub(crate) const TRANSCRIPT_HASH_BYTES: usize = 32;
+
 /// Iterated arbitrary-base Gray code functionaity.
 pub(crate) mod gray;
 /// Public parameters used for generating and verifying Triptych proofs.

--- a/src/parallel/statement.rs
+++ b/src/parallel/statement.rs
@@ -1,13 +1,12 @@
 // Copyright (c) 2024, The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-use alloc::{sync::Arc, vec::Vec};
+use alloc::{sync::Arc, vec, vec::Vec};
 
-use blake3::Hasher;
 use curve25519_dalek::{traits::Identity, RistrettoPoint};
 use snafu::prelude::*;
 
-use crate::parallel::TriptychParameters;
+use crate::{parallel::TriptychParameters, Transcript, TRANSCRIPT_HASH_BYTES};
 
 /// A Triptych input set.
 ///
@@ -22,6 +21,8 @@ pub struct TriptychInputSet {
 }
 
 impl TriptychInputSet {
+    // Domain separator used for hashing
+    const DOMAIN: &'static str = "Parallel Triptych input set";
     // Version identifier used for hashing
     const VERSION: u64 = 0;
 
@@ -84,22 +85,23 @@ impl TriptychInputSet {
         // Ensure the verification key vector lengths don't overflow
         let unpadded_size = u32::try_from(unpadded_size).map_err(|_| StatementError::InvalidParameter)?;
 
-        // Use `BLAKE3` for the transcript hash
-        let mut hasher = Hasher::new();
-        hasher.update(b"Parallel Triptych InputSet");
-        hasher.update(&Self::VERSION.to_le_bytes());
-        hasher.update(&unpadded_size.to_le_bytes());
+        // Use Merlin for the transcript hash
+        let mut transcript = Transcript::new(Self::DOMAIN.as_bytes());
+        transcript.append_u64(b"version", Self::VERSION);
+        transcript.append_message(b"unpadded_size", &unpadded_size.to_le_bytes());
         for item in M {
-            hasher.update(item.compress().as_bytes());
+            transcript.append_message(b"M", item.compress().as_bytes());
         }
         for item in M1 {
-            hasher.update(item.compress().as_bytes());
+            transcript.append_message(b"M1", item.compress().as_bytes());
         }
+        let mut hash = vec![0u8; TRANSCRIPT_HASH_BYTES];
+        transcript.challenge_bytes(b"hash", &mut hash);
 
         Ok(Self {
             M: M.to_vec(),
             M1: M1.to_vec(),
-            hash: hasher.finalize().as_bytes().to_vec(),
+            hash,
         })
     }
 
@@ -131,6 +133,7 @@ pub struct TriptychStatement {
     input_set: Arc<TriptychInputSet>,
     offset: RistrettoPoint,
     J: RistrettoPoint,
+    hash: Vec<u8>,
 }
 
 /// Errors that can arise relating to [`TriptychStatement`].
@@ -142,6 +145,11 @@ pub enum StatementError {
 }
 
 impl TriptychStatement {
+    // Domain separator used for hashing
+    const DOMAIN: &'static str = "Parallel Triptych statement";
+    // Version identifier used for hashing
+    const VERSION: u64 = 0;
+
     /// Generate a new [`TriptychStatement`].
     ///
     /// The [`TriptychInputSet`] `input_set` must have a verification key vector whose size matches that specified by
@@ -175,11 +183,22 @@ impl TriptychStatement {
             return Err(StatementError::InvalidParameter);
         }
 
+        // Use Merlin for the transcript hash
+        let mut transcript = Transcript::new(Self::DOMAIN.as_bytes());
+        transcript.append_u64(b"version", Self::VERSION);
+        transcript.append_message(b"params", params.get_hash());
+        transcript.append_message(b"input_set", input_set.get_hash());
+        transcript.append_message(b"offset", offset.compress().as_bytes());
+        transcript.append_message(b"J", J.compress().as_bytes());
+        let mut hash = vec![0u8; TRANSCRIPT_HASH_BYTES];
+        transcript.challenge_bytes(b"hash", &mut hash);
+
         Ok(Self {
             params: params.clone(),
             input_set: input_set.clone(),
             offset: *offset,
             J: *J,
+            hash,
         })
     }
 
@@ -202,6 +221,11 @@ impl TriptychStatement {
     #[allow(non_snake_case)]
     pub fn get_J(&self) -> &RistrettoPoint {
         &self.J
+    }
+
+    /// Get a cryptographic hash representation of this [`TriptychStatement`], suitable for transcripting.
+    pub(crate) fn get_hash(&self) -> &[u8] {
+        &self.hash
     }
 }
 

--- a/src/parallel/transcript.rs
+++ b/src/parallel/transcript.rs
@@ -12,12 +12,6 @@ use crate::{
     Transcript,
 };
 
-// Version identifier
-const VERSION: u64 = 0;
-
-// Domain separator
-const DOMAIN: &str = "Parallel Triptych proof";
-
 /// A Triptych proof transcript.
 pub(crate) struct ProofTranscript<'a, R: CryptoRngCore> {
     transcript: &'a mut Transcript,
@@ -27,6 +21,11 @@ pub(crate) struct ProofTranscript<'a, R: CryptoRngCore> {
 }
 
 impl<'a, R: CryptoRngCore> ProofTranscript<'a, R> {
+    // Domain separator used for hashing
+    const DOMAIN: &'static str = "Parallel Triptych proof";
+    // Version identifier used for hashing
+    const VERSION: u64 = 0;
+
     /// Initialize a transcript.
     pub(crate) fn new(
         transcript: &'a mut Transcript,
@@ -35,12 +34,9 @@ impl<'a, R: CryptoRngCore> ProofTranscript<'a, R> {
         witness: Option<&'a TriptychWitness>,
     ) -> Self {
         // Update the transcript
-        transcript.append_message(b"dom-sep", DOMAIN.as_bytes());
-        transcript.append_u64(b"version", VERSION);
-        transcript.append_message(b"params", statement.get_params().get_hash());
-        transcript.append_message(b"M", statement.get_input_set().get_hash());
-        transcript.append_message(b"offset", statement.get_offset().compress().as_bytes());
-        transcript.append_message(b"J", statement.get_J().compress().as_bytes());
+        transcript.append_message(b"dom-sep", Self::DOMAIN.as_bytes());
+        transcript.append_u64(b"version", Self::VERSION);
+        transcript.append_message(b"statement", statement.get_hash());
 
         // Set up the transcript generator
         let transcript_rng = Self::build_transcript_rng(transcript, witness, external_rng);

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2024, The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 use core::iter::once;
 
 use blake3::Hasher;
@@ -13,7 +13,7 @@ use curve25519_dalek::{
 };
 use snafu::prelude::*;
 
-use crate::util::OperationTiming;
+use crate::{util::OperationTiming, Transcript, TRANSCRIPT_HASH_BYTES};
 
 /// Public parameters used for generating and verifying Triptych proofs.
 ///
@@ -42,6 +42,8 @@ pub enum ParameterError {
 }
 
 impl TriptychParameters {
+    // Domain separator used for hashing
+    const DOMAIN: &'static str = "Triptych parameters";
     // Version identifier used for hashing
     const VERSION: u64 = 0;
 
@@ -111,18 +113,19 @@ impl TriptychParameters {
             })
             .collect::<Vec<RistrettoPoint>>();
 
-        // Use `BLAKE3` for the transcript hash
-        let mut hasher = Hasher::new();
-        hasher.update(b"Triptych Parameters");
-        hasher.update(&Self::VERSION.to_le_bytes());
-        hasher.update(&n.to_le_bytes());
-        hasher.update(&m.to_le_bytes());
-        hasher.update(G.compress().as_bytes());
-        hasher.update(U.compress().as_bytes());
+        // Use Merlin for the transcript hash
+        let mut transcript = Transcript::new(Self::DOMAIN.as_bytes());
+        transcript.append_u64(b"version", Self::VERSION);
+        transcript.append_message(b"n", &n.to_le_bytes());
+        transcript.append_message(b"m", &m.to_le_bytes());
+        transcript.append_message(b"G", G.compress().as_bytes());
+        transcript.append_message(b"U", U.compress().as_bytes());
         for item in &CommitmentG {
-            hasher.update(item.compress().as_bytes());
+            transcript.append_message(b"CommitmentG", item.compress().as_bytes());
         }
-        hasher.update(CommitmentH.compress().as_bytes());
+        transcript.append_message(b"CommitmentH", CommitmentH.compress().as_bytes());
+        let mut hash = vec![0u8; TRANSCRIPT_HASH_BYTES];
+        transcript.challenge_bytes(b"hash", &mut hash);
 
         Ok(TriptychParameters {
             n,
@@ -131,7 +134,7 @@ impl TriptychParameters {
             U: *U,
             CommitmentG,
             CommitmentH,
-            hash: hasher.finalize().as_bytes().to_vec(),
+            hash,
         })
     }
 

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -9,12 +9,6 @@ use rand_core::CryptoRngCore;
 
 use crate::{proof::ProofError, Transcript, TriptychParameters, TriptychStatement, TriptychWitness};
 
-// Version identifier
-const VERSION: u64 = 0;
-
-// Domain separator
-const DOMAIN: &str = "Triptych proof";
-
 /// A Triptych proof transcript.
 pub(crate) struct ProofTranscript<'a, R: CryptoRngCore> {
     transcript: &'a mut Transcript,
@@ -24,6 +18,11 @@ pub(crate) struct ProofTranscript<'a, R: CryptoRngCore> {
 }
 
 impl<'a, R: CryptoRngCore> ProofTranscript<'a, R> {
+    // Domain separator used for hashing
+    const DOMAIN: &'static str = "Triptych proof";
+    // Version identifier used for hashing
+    const VERSION: u64 = 0;
+
     /// Initialize a transcript.
     pub(crate) fn new(
         transcript: &'a mut Transcript,
@@ -32,11 +31,9 @@ impl<'a, R: CryptoRngCore> ProofTranscript<'a, R> {
         witness: Option<&'a TriptychWitness>,
     ) -> Self {
         // Update the transcript
-        transcript.append_message(b"dom-sep", DOMAIN.as_bytes());
-        transcript.append_u64(b"version", VERSION);
-        transcript.append_message(b"params", statement.get_params().get_hash());
-        transcript.append_message(b"M", statement.get_input_set().get_hash());
-        transcript.append_message(b"J", statement.get_J().compress().as_bytes());
+        transcript.append_message(b"dom-sep", Self::DOMAIN.as_bytes());
+        transcript.append_u64(b"version", Self::VERSION);
+        transcript.append_message(b"statement", statement.get_hash());
 
         // Set up the transcript generator
         let transcript_rng = Self::build_transcript_rng(transcript, witness, external_rng);


### PR DESCRIPTION
This PR changes the transcript hashing of parameters and input sets to use Merlin, and adds this functionality for statements as well. Doing so makes the construction of transcripts more robust against changes.

Closes #82.