### PR TITLE
fix: update curve library dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["cryptography"]
 [dependencies]
 blake3 = { version = "1.5.1", default-features = false }
 crypto-bigint = { version = "0.5.5", default-features = false }
-curve25519-dalek = { version = "4.1.2", default-features = false, features = ["alloc", "digest", "rand_core", "zeroize"] }
+curve25519-dalek = { version = "4.1.3", default-features = false, features = ["alloc", "digest", "rand_core", "zeroize"] }
 itertools = { version = "0.12.1", default-features = false }
 merlin = { version = "3.0.0", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }


### PR DESCRIPTION
The curve library has a [timing-related vulnerability](https://github.com/advisories/GHSA-x4gp-pqpj-f43q) that was recently patched. This PR updates this dependency to require the patch.