### PR TITLE
chore!: rename generator

### DIFF
--- a/benches/parallel.rs
+++ b/benches/parallel.rs
@@ -60,7 +60,7 @@ fn generate_data<R: CryptoRngCore>(
     for witness in &witnesses {
         M[witness.get_l() as usize] = witness.compute_verification_key();
         let r_offset = Scalar::random(rng);
-        offsets.push(r_offset * params.get_H());
+        offsets.push(r_offset * params.get_G1());
         M1[witness.get_l() as usize] = witness.compute_auxiliary_verification_key() + offsets.last().unwrap();
     }
     let input_set = Arc::new(TriptychInputSet::new(&M, &M1).unwrap());

--- a/src/parallel/mod.rs
+++ b/src/parallel/mod.rs
@@ -6,12 +6,12 @@
 //! It's possible to extend Triptych proving functionality to the case where each element of an input set if composed of
 //! two keys, a verification key and an auxiliary verification key. This enables additional functionality.
 //!
-//! More formally, let `G`, `H`, and `U` be fixed independent generators of the Ristretto group.
+//! More formally, let `G`, `G1`, and `U` be fixed independent generators of the Ristretto group.
 //! Let `N = n**m`, where `n, m > 1` are fixed parameters.
 //! The parallel Triptych proving system protocol is a sigma protocol for the following relation, where `M` and `M1` are
 //! both `N`-vectors of group elements:
 //!
-//! `{ M, M1, offset, J ; (l, r, r1) : M[l] = r*G, M1[l] - offset = r1*H, r*J = U }`
+//! `{ M, M1, offset, J ; (l, r, r1) : M[l] = r*G, M1[l] - offset = r1*G1, r*J = U }`
 //!
 //! # Example
 //!
@@ -40,7 +40,7 @@
 //! let witness = TriptychWitness::random(&params, &mut rng);
 //!
 //! // Select a random offset
-//! let offset = Scalar::random(&mut rng) * params.get_H();
+//! let offset = Scalar::random(&mut rng) * params.get_G1();
 //!
 //! // Generate an input set of random verification keys, placing ours at the chosen index
 //! // This is `Arc`-wrapped to facilitate efficient reuse!
@@ -56,7 +56,7 @@
 //! let M1 = (0..params.get_N())
 //!     .map(|i| {
 //!         if i == witness.get_l() {
-//!             // This ensures that `M1[l] - offset = r1 * H` to satisfy the proving relation
+//!             // This ensures that `M1[l] - offset = r1 * G1` to satisfy the proving relation
 //!             witness.compute_auxiliary_verification_key() + offset
 //!         } else {
 //!             RistrettoPoint::random(&mut rng)

--- a/src/parallel/proof.rs
+++ b/src/parallel/proof.rs
@@ -204,7 +204,7 @@ impl TriptychProof {
         if M_l != r * params.get_G() {
             return Err(ProofError::InvalidParameter);
         }
-        if M1_l - offset != r1 * params.get_H() {
+        if M1_l - offset != r1 * params.get_G1() {
             return Err(ProofError::InvalidParameter);
         }
         if &(r * J) != params.get_U() {
@@ -356,7 +356,7 @@ impl TriptychProof {
             .enumerate()
             .map(|(j, rho1)| {
                 let minus_offset = -offset;
-                let X_points = M1.iter().chain(once(params.get_H())).chain(once(&minus_offset));
+                let X_points = M1.iter().chain(once(params.get_G1())).chain(once(&minus_offset));
                 let p_sum: Scalar = p.iter().map(|p| &p[j]).sum();
                 let X_scalars = p.iter().map(|p| &p[j]).chain(once(rho1)).chain(once(&p_sum));
 
@@ -646,7 +646,7 @@ impl TriptychProof {
                     .chain(once(s.get_offset()))
             })
             .chain(once(params.get_G()))
-            .chain(once(params.get_H()))
+            .chain(once(params.get_G1()))
             .chain(params.get_CommitmentG().iter())
             .chain(once(params.get_CommitmentH()))
             .chain(M.iter())
@@ -1068,7 +1068,7 @@ mod test {
             M[witness.get_l() as usize] = witness.compute_verification_key();
 
             let r_offset = Scalar::random(rng);
-            offsets.push(r_offset * params.get_H());
+            offsets.push(r_offset * params.get_G1());
             M1[witness.get_l() as usize] = witness.compute_auxiliary_verification_key() + offsets.last().unwrap();
         }
         let input_set = Arc::new(TriptychInputSet::new(&M, &M1).unwrap());

--- a/src/parallel/witness.rs
+++ b/src/parallel/witness.rs
@@ -111,6 +111,6 @@ impl TriptychWitness {
 
     /// Compute the auxiliary verification key for the [`TriptychWitness`] signing key.
     pub fn compute_auxiliary_verification_key(&self) -> RistrettoPoint {
-        self.r1 * self.params.get_H()
+        self.r1 * self.params.get_G1()
     }
 }


### PR DESCRIPTION
Parallel proofs support the use of separate generators for verification and auxiliary verification keys. Currently, the notation `H` is used for the latter, which may be confusing depending on use case by conflicting with other notation (like Pedersen commitments).

This PR renames the generator to `G1`, which is also more in line with how input sets are defined.

BREAKING CHANGE: Changes the public API for parallel proofs.