### PR TITLE
chore: update default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ criterion = { version = "0.5.1", default-features = false, features = ["cargo_be
 rand_chacha = { version = "0.3.1", default-features = false }
 
 [features]
-default = ["borsh", "rand", "serde", "std"]
+default = ["rand", "std"]
 borsh = ["dep:borsh"]
 rand = ["rand_core/getrandom"]
 serde = ["dep:serde", "curve25519-dalek/serde", "zeroize/serde"]

--- a/README.md
+++ b/README.md
@@ -32,11 +32,14 @@ This implementation makes several opinionated choices:
 
 The implementation keeps dependencies to a minimum, and is `no_std` friendly.
 
-There are several features that are enabled by default:
-- `borsh`: adds proof serialization and deserialization via `borsh`
-- `rand`: adds additional prover functionality that supplies a cryptographically-secure random number generator
-- `serde`: adds proof serialization and deserialization via `serde`
-- `std`: adds corresponding dependency features
+There are several features available.
+
+| Feature | Default? | Description |
+| :--- | --- | :--- |
+| `borsh` | | Adds proof serialization and deserialization via [`borsh`](https://crates.io/crates/borsh) |
+| `serde` | | Adds proof serialization and deserialization via [`serde`](https://crates.io/crates/serde) |
+| `rand` | ✓ | Adds additional prover functionality that supplies a cryptographically-secure random number generator |
+| `std` | ✓ | Adds corresponding dependency features |
 
 The underlying [curve library](https://crates.io/crates/curve25519-dalek) chooses an arithmetic backend based on CPU feature detection.
 Using a nightly compiler broadens the backend set, and may provide better performance.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,11 +36,14 @@
 //!
 //! The implementation keeps dependencies to a minimum, and is `no_std` friendly.
 //!
-//! There are several features that are enabled by default:
-//! - `borsh`: adds proof serialization and deserialization via `borsh`
-//! - `rand`: adds additional prover functionality that supplies a cryptographically-secure random number generator
-//! - `serde`: adds proof serialization and deserialization via `serde`
-//! - `std`: adds corresponding dependency features
+//! There are several features available.
+//!
+//! | Feature | Default? | Description |
+//! | :--- | --- | :--- |
+//! | `borsh` | | Adds proof serialization and deserialization via [`borsh`](https://crates.io/crates/borsh) |
+//! | `serde` | | Adds proof serialization and deserialization via [`serde`](https://crates.io/crates/serde) |
+//! | `rand` | ✓ | Adds additional prover functionality that supplies a cryptographically-secure random number generator |
+//! | `std` | ✓ | Adds corresponding dependency features |
 //!
 //! The underlying [curve library](https://crates.io/crates/curve25519-dalek) chooses an arithmetic backend based on CPU feature detection.
 //! Using a nightly compiler broadens the backend set, and may provide better performance.


### PR DESCRIPTION
This PR makes `borsh` and `serde` optional features.