### PR TITLE
chore!: relax `Arc` requirement for input sets

### DIFF
--- a/benches/parallel.rs
+++ b/benches/parallel.rs
@@ -63,7 +63,7 @@ fn generate_data<R: CryptoRngCore>(
         offsets.push(r_offset * params.get_G1());
         M1[witness.get_l() as usize] = witness.compute_auxiliary_verification_key() + offsets.last().unwrap();
     }
-    let input_set = Arc::new(TriptychInputSet::new(&M, &M1).unwrap());
+    let input_set = TriptychInputSet::new(&M, &M1).unwrap();
 
     // Generate statements
     let mut statements = Vec::with_capacity(b);

--- a/benches/triptych.rs
+++ b/benches/triptych.rs
@@ -53,7 +53,7 @@ fn generate_data<R: CryptoRngCore>(
     for witness in &witnesses {
         M[witness.get_l() as usize] = witness.compute_verification_key();
     }
-    let input_set = Arc::new(TriptychInputSet::new(&M).unwrap());
+    let input_set = TriptychInputSet::new(&M).unwrap();
 
     // Generate statements
     let mut statements = Vec::with_capacity(b);

--- a/examples/ringct.rs
+++ b/examples/ringct.rs
@@ -66,9 +66,8 @@ mod test {
         let witness = TriptychWitness::new(&params, index, &signing_key, &(commitment_mask - offset_mask)).unwrap();
 
         // We can also set up the input set and statement
-        // The input set is `Arc`-wrapped since it's likely it could be reused
         // The linkable ring signature also comes equipped with a linking tag; the library can compute it for us
-        let input_set = Arc::new(TriptychInputSet::new(&output_keys, &value_commitments).unwrap());
+        let input_set = TriptychInputSet::new(&output_keys, &value_commitments).unwrap();
         let statement = TriptychStatement::new(&params, &input_set, &offset, &witness.compute_linking_tag()).unwrap();
 
         // The proof needs a transcript associated to it

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,6 @@
 //! let witness = TriptychWitness::random(&params, &mut rng);
 //!
 //! // Generate an input set of random verification keys, placing ours at the chosen index
-//! // This is `Arc`-wrapped to facilitate efficient reuse!
 //! let M = (0..params.get_N())
 //!     .map(|i| {
 //!         if i == witness.get_l() {
@@ -96,7 +95,7 @@
 //!         }
 //!     })
 //!     .collect::<Vec<RistrettoPoint>>();
-//! let input_set = Arc::new(TriptychInputSet::new(&M).unwrap());
+//! let input_set = TriptychInputSet::new(&M).unwrap();
 //!
 //! // Generate the statement, which includes the verification key vector and linking tag
 //! let J = witness.compute_linking_tag();

--- a/src/parallel/mod.rs
+++ b/src/parallel/mod.rs
@@ -43,7 +43,6 @@
 //! let offset = Scalar::random(&mut rng) * params.get_G1();
 //!
 //! // Generate an input set of random verification keys, placing ours at the chosen index
-//! // This is `Arc`-wrapped to facilitate efficient reuse!
 //! let M = (0..params.get_N())
 //!     .map(|i| {
 //!         if i == witness.get_l() {
@@ -63,7 +62,7 @@
 //!         }
 //!     })
 //!     .collect::<Vec<RistrettoPoint>>();
-//! let input_set = Arc::new(TriptychInputSet::new(&M, &M1).unwrap());
+//! let input_set = TriptychInputSet::new(&M, &M1).unwrap();
 //!
 //! // Generate the statement, which includes the verification key vectors and linking tag
 //! let J = witness.compute_linking_tag();

--- a/src/parallel/statement.rs
+++ b/src/parallel/statement.rs
@@ -15,8 +15,8 @@ use crate::{parallel::TriptychParameters, Transcript, TRANSCRIPT_HASH_BYTES};
 #[allow(non_snake_case)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TriptychInputSet {
-    M: Vec<RistrettoPoint>,
-    M1: Vec<RistrettoPoint>,
+    M: Arc<Vec<RistrettoPoint>>,
+    M1: Arc<Vec<RistrettoPoint>>,
     hash: Vec<u8>,
 }
 
@@ -99,8 +99,8 @@ impl TriptychInputSet {
         transcript.challenge_bytes(b"hash", &mut hash);
 
         Ok(Self {
-            M: M.to_vec(),
-            M1: M1.to_vec(),
+            M: Arc::new(M.to_vec()),
+            M1: Arc::new(M1.to_vec()),
             hash,
         })
     }
@@ -130,7 +130,7 @@ impl TriptychInputSet {
 #[derive(Clone, Eq, PartialEq)]
 pub struct TriptychStatement {
     params: Arc<TriptychParameters>,
-    input_set: Arc<TriptychInputSet>,
+    input_set: TriptychInputSet,
     offset: RistrettoPoint,
     J: RistrettoPoint,
     hash: Vec<u8>,
@@ -162,7 +162,7 @@ impl TriptychStatement {
     #[allow(non_snake_case)]
     pub fn new(
         params: &Arc<TriptychParameters>,
-        input_set: &Arc<TriptychInputSet>,
+        input_set: &TriptychInputSet,
         offset: &RistrettoPoint,
         J: &RistrettoPoint,
     ) -> Result<Self, StatementError> {
@@ -208,7 +208,7 @@ impl TriptychStatement {
     }
 
     /// Get the input set for this [`TriptychStatement`].
-    pub fn get_input_set(&self) -> &Arc<TriptychInputSet> {
+    pub fn get_input_set(&self) -> &TriptychInputSet {
         &self.input_set
     }
 

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -998,7 +998,7 @@ mod test {
         for witness in &witnesses {
             M[witness.get_l() as usize] = witness.compute_verification_key();
         }
-        let input_set = Arc::new(TriptychInputSet::new(&M).unwrap());
+        let input_set = TriptychInputSet::new(&M).unwrap();
 
         // Generate statements
         let mut statements = Vec::with_capacity(b);
@@ -1282,7 +1282,7 @@ mod test {
         let mut M = statements[0].get_input_set().get_keys().to_vec();
         let index = ((witnesses[0].get_l() + 1) % witnesses[0].get_params().get_N()) as usize;
         M[index] = RistrettoPoint::random(&mut rng);
-        let evil_input_set = Arc::new(TriptychInputSet::new(&M).unwrap());
+        let evil_input_set = TriptychInputSet::new(&M).unwrap();
         let evil_statement =
             TriptychStatement::new(statements[0].get_params(), &evil_input_set, statements[0].get_J()).unwrap();
 

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -15,7 +15,7 @@ use crate::{Transcript, TriptychParameters, TRANSCRIPT_HASH_BYTES};
 #[allow(non_snake_case)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TriptychInputSet {
-    M: Vec<RistrettoPoint>,
+    M: Arc<Vec<RistrettoPoint>>,
     hash: Vec<u8>,
 }
 
@@ -74,7 +74,10 @@ impl TriptychInputSet {
         let mut hash = vec![0u8; TRANSCRIPT_HASH_BYTES];
         transcript.challenge_bytes(b"hash", &mut hash);
 
-        Ok(Self { M: M.to_vec(), hash })
+        Ok(Self {
+            M: Arc::new(M.to_vec()),
+            hash,
+        })
     }
 
     /// Get the verification keys for this [`TriptychInputSet`].
@@ -96,7 +99,7 @@ impl TriptychInputSet {
 #[derive(Clone, Eq, PartialEq)]
 pub struct TriptychStatement {
     params: Arc<TriptychParameters>,
-    input_set: Arc<TriptychInputSet>,
+    input_set: TriptychInputSet,
     J: RistrettoPoint,
     hash: Vec<u8>,
 }
@@ -127,7 +130,7 @@ impl TriptychStatement {
     #[allow(non_snake_case)]
     pub fn new(
         params: &Arc<TriptychParameters>,
-        input_set: &Arc<TriptychInputSet>,
+        input_set: &TriptychInputSet,
         J: &RistrettoPoint,
     ) -> Result<Self, StatementError> {
         // Check that the input vector is valid against the parameters
@@ -161,7 +164,7 @@ impl TriptychStatement {
     }
 
     /// Get the input set for this [`TriptychStatement`].
-    pub fn get_input_set(&self) -> &Arc<TriptychInputSet> {
+    pub fn get_input_set(&self) -> &TriptychInputSet {
         &self.input_set
     }
 


### PR DESCRIPTION
This PR relaxes the `Arc` requirement for input sets.

Specifically, it removes the requirement that the caller use an `Arc` wrapper for a `TriptychInputSet` in order to use it to generate a statement. Instead, this wrapping is handled internally.

Partially addresses #65.

BREAKING CHANGE: Updates the public API.