### PR TITLE
chore!: refactor hashing domains

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,8 +116,6 @@ extern crate alloc;
 
 pub use merlin::Transcript;
 
-pub(crate) const TRANSCRIPT_HASH_BYTES: usize = 32;
-
 /// Iterated arbitrary-base Gray code functionality.
 pub(crate) mod gray;
 /// Public parameters used for generating and verifying Triptych proofs.
@@ -139,3 +137,32 @@ pub use witness::TriptychWitness;
 
 /// Parallel Triptych functionality.
 pub mod parallel;
+
+/// Domain separators used for hashing operations
+pub(crate) mod domains {
+    // Version
+    pub(crate) const VERSION: u64 = 0;
+
+    // Number of bytes in a transcript hash
+    pub(crate) const TRANSCRIPT_HASH_BYTES: usize = 32;
+
+    // Parameters
+    pub(crate) const TRANSCRIPT_PARAMETERS: &str = "Triptych parameters";
+    pub(crate) const TRANSCRIPT_PARALLEL_PARAMETERS: &str = "Parallel Triptych parameters";
+    pub(crate) const POINT_G1: &str = "Triptych G1";
+    pub(crate) const POINT_U: &str = "Triptych U";
+    pub(crate) const POINT_COMMITMENT_G: &str = "Triptych CommitmentG";
+    pub(crate) const POINT_COMMITMENT_H: &str = "Triptych CommitmentH";
+
+    // Statement
+    pub(crate) const TRANSCRIPT_INPUT_SET: &str = "Triptych input set";
+    pub(crate) const TRANSCRIPT_PARALLEL_INPUT_SET: &str = "Parallel Triptych input set";
+    pub(crate) const TRANSCRIPT_STATEMENT: &str = "Triptych statement";
+    pub(crate) const TRANSCRIPT_PARALLEL_STATEMENT: &str = "Parallel Triptych statement";
+
+    // Proof
+    pub(crate) const TRANSCRIPT_PROOF: &str = "Triptych proof";
+    pub(crate) const TRANSCRIPT_PARALLEL_PROOF: &str = "Parallel Triptych proof";
+    pub(crate) const TRANSCRIPT_VERIFIER_WEIGHTS: &str = "Triptych verifier weights";
+    pub(crate) const TRANSCRIPT_PARALLEL_VERIFIER_WEIGHTS: &str = "Parallel Triptych verifier weights";
+}

--- a/src/parallel/proof.rs
+++ b/src/parallel/proof.rs
@@ -21,6 +21,7 @@ use subtle::{ConditionallySelectable, ConstantTimeEq};
 use zeroize::Zeroizing;
 
 use crate::{
+    domains,
     gray::GrayIterator,
     parallel::{transcript::ProofTranscript, TriptychStatement, TriptychWitness},
     util::{delta, NullRng, OperationTiming},
@@ -722,7 +723,8 @@ impl TriptychProof {
         let mut U_scalar = Scalar::ZERO;
 
         // Set up a transcript generator for use in weighting
-        let mut transcript_weights = Transcript::new(b"Triptych verifier weights");
+        let mut transcript_weights = Transcript::new(domains::TRANSCRIPT_PARALLEL_VERIFIER_WEIGHTS.as_bytes());
+        transcript_weights.append_u64(b"version", domains::VERSION);
 
         let mut null_rng = NullRng;
 

--- a/src/parallel/transcript.rs
+++ b/src/parallel/transcript.rs
@@ -8,6 +8,7 @@ use merlin::TranscriptRng;
 use rand_core::CryptoRngCore;
 
 use crate::{
+    domains,
     parallel::{proof::ProofError, TriptychParameters, TriptychStatement, TriptychWitness},
     Transcript,
 };
@@ -21,11 +22,6 @@ pub(crate) struct ProofTranscript<'a, R: CryptoRngCore> {
 }
 
 impl<'a, R: CryptoRngCore> ProofTranscript<'a, R> {
-    // Domain separator used for hashing
-    const DOMAIN: &'static str = "Parallel Triptych proof";
-    // Version identifier used for hashing
-    const VERSION: u64 = 0;
-
     /// Initialize a transcript.
     pub(crate) fn new(
         transcript: &'a mut Transcript,
@@ -34,8 +30,8 @@ impl<'a, R: CryptoRngCore> ProofTranscript<'a, R> {
         witness: Option<&'a TriptychWitness>,
     ) -> Self {
         // Update the transcript
-        transcript.append_message(b"dom-sep", Self::DOMAIN.as_bytes());
-        transcript.append_u64(b"version", Self::VERSION);
+        transcript.append_message(b"dom-sep", domains::TRANSCRIPT_PARALLEL_PROOF.as_bytes());
+        transcript.append_u64(b"version", domains::VERSION);
         transcript.append_message(b"statement", statement.get_hash());
 
         // Set up the transcript generator

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -21,6 +21,7 @@ use subtle::{ConditionallySelectable, ConstantTimeEq};
 use zeroize::Zeroizing;
 
 use crate::{
+    domains,
     gray::GrayIterator,
     transcript::ProofTranscript,
     util::{delta, NullRng, OperationTiming},
@@ -668,7 +669,8 @@ impl TriptychProof {
         let mut U_scalar = Scalar::ZERO;
 
         // Set up a transcript generator for use in weighting
-        let mut transcript_weights = Transcript::new(b"Triptych verifier weights");
+        let mut transcript_weights = Transcript::new(domains::TRANSCRIPT_VERIFIER_WEIGHTS.as_bytes());
+        transcript_weights.append_u64(b"version", domains::VERSION);
 
         let mut null_rng = NullRng;
 

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -7,7 +7,7 @@ use curve25519_dalek::{RistrettoPoint, Scalar};
 use merlin::TranscriptRng;
 use rand_core::CryptoRngCore;
 
-use crate::{proof::ProofError, Transcript, TriptychParameters, TriptychStatement, TriptychWitness};
+use crate::{domains, proof::ProofError, Transcript, TriptychParameters, TriptychStatement, TriptychWitness};
 
 /// A Triptych proof transcript.
 pub(crate) struct ProofTranscript<'a, R: CryptoRngCore> {
@@ -18,11 +18,6 @@ pub(crate) struct ProofTranscript<'a, R: CryptoRngCore> {
 }
 
 impl<'a, R: CryptoRngCore> ProofTranscript<'a, R> {
-    // Domain separator used for hashing
-    const DOMAIN: &'static str = "Triptych proof";
-    // Version identifier used for hashing
-    const VERSION: u64 = 0;
-
     /// Initialize a transcript.
     pub(crate) fn new(
         transcript: &'a mut Transcript,
@@ -31,8 +26,8 @@ impl<'a, R: CryptoRngCore> ProofTranscript<'a, R> {
         witness: Option<&'a TriptychWitness>,
     ) -> Self {
         // Update the transcript
-        transcript.append_message(b"dom-sep", Self::DOMAIN.as_bytes());
-        transcript.append_u64(b"version", Self::VERSION);
+        transcript.append_message(b"dom-sep", domains::TRANSCRIPT_PROOF.as_bytes());
+        transcript.append_u64(b"version", domains::VERSION);
         transcript.append_message(b"statement", statement.get_hash());
 
         // Set up the transcript generator


### PR DESCRIPTION
This PR moves hashing domains to a common module, in order to reduce the risk of collisions. It also ensures that all hashing operations are versioned.

BREAKING CHANGE: Updates how some hashing operations are performed, which will break existing proofs.