### PR TITLE
Use `expect` for lint exceptions

### DIFF
--- a/benches/parallel.rs
+++ b/benches/parallel.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2024, The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-#![allow(missing_docs)]
+#![expect(missing_docs)]
 
 #[macro_use]
 extern crate criterion;
@@ -27,8 +27,8 @@ const M_VALUES: [u32; 4] = [2, 4, 8, 10];
 const BATCH_SIZES: [usize; 1] = [2];
 
 // Generate a batch of witnesses, statements, and transcripts
-#[allow(non_snake_case)]
-#[allow(clippy::arithmetic_side_effects)]
+#[expect(non_snake_case)]
+#[expect(clippy::arithmetic_side_effects)]
 fn generate_data<R: CryptoRngCore>(
     params: &TriptychParameters,
     b: usize,
@@ -82,8 +82,6 @@ fn generate_data<R: CryptoRngCore>(
     (witnesses, statements, transcripts)
 }
 
-#[allow(non_snake_case)]
-#[allow(non_upper_case_globals)]
 fn generate_proof(c: &mut Criterion) {
     let mut group = c.benchmark_group("generate_proof");
     let mut rng = ChaCha12Rng::seed_from_u64(8675309);
@@ -113,8 +111,6 @@ fn generate_proof(c: &mut Criterion) {
     group.finish();
 }
 
-#[allow(non_snake_case)]
-#[allow(non_upper_case_globals)]
 fn generate_proof_vartime(c: &mut Criterion) {
     let mut group = c.benchmark_group("generate_proof_vartime");
     let mut rng = ChaCha12Rng::seed_from_u64(8675309);
@@ -149,8 +145,6 @@ fn generate_proof_vartime(c: &mut Criterion) {
     group.finish();
 }
 
-#[allow(non_snake_case)]
-#[allow(non_upper_case_globals)]
 fn verify_proof(c: &mut Criterion) {
     let mut group = c.benchmark_group("verify_proof");
     let mut rng = ChaCha12Rng::seed_from_u64(8675309);
@@ -185,8 +179,6 @@ fn verify_proof(c: &mut Criterion) {
     group.finish();
 }
 
-#[allow(non_snake_case)]
-#[allow(non_upper_case_globals)]
 fn verify_batch_proof(c: &mut Criterion) {
     let mut group = c.benchmark_group("verify_batch_proof");
     let mut rng = ChaCha12Rng::seed_from_u64(8675309);

--- a/benches/triptych.rs
+++ b/benches/triptych.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2024, The Tari Project
 // SPDX-License-Identifier: BSD-3-Clause
 
-#![allow(missing_docs)]
+#![expect(missing_docs)]
 
 #[macro_use]
 extern crate criterion;
@@ -25,8 +25,8 @@ const M_VALUES: [u32; 4] = [2, 4, 8, 10];
 const BATCH_SIZES: [usize; 1] = [2];
 
 // Generate a batch of witnesses, statements, and transcripts
-#[allow(non_snake_case)]
-#[allow(clippy::arithmetic_side_effects)]
+#[expect(non_snake_case)]
+#[expect(clippy::arithmetic_side_effects)]
 fn generate_data<R: CryptoRngCore>(
     params: &TriptychParameters,
     b: usize,
@@ -72,8 +72,6 @@ fn generate_data<R: CryptoRngCore>(
     (witnesses, statements, transcripts)
 }
 
-#[allow(non_snake_case)]
-#[allow(non_upper_case_globals)]
 fn generate_proof(c: &mut Criterion) {
     let mut group = c.benchmark_group("generate_proof");
     let mut rng = ChaCha12Rng::seed_from_u64(8675309);
@@ -103,8 +101,6 @@ fn generate_proof(c: &mut Criterion) {
     group.finish();
 }
 
-#[allow(non_snake_case)]
-#[allow(non_upper_case_globals)]
 fn generate_proof_vartime(c: &mut Criterion) {
     let mut group = c.benchmark_group("generate_proof_vartime");
     let mut rng = ChaCha12Rng::seed_from_u64(8675309);
@@ -139,8 +135,6 @@ fn generate_proof_vartime(c: &mut Criterion) {
     group.finish();
 }
 
-#[allow(non_snake_case)]
-#[allow(non_upper_case_globals)]
 fn verify_proof(c: &mut Criterion) {
     let mut group = c.benchmark_group("verify_proof");
     let mut rng = ChaCha12Rng::seed_from_u64(8675309);
@@ -175,8 +169,6 @@ fn verify_proof(c: &mut Criterion) {
     group.finish();
 }
 
-#[allow(non_snake_case)]
-#[allow(non_upper_case_globals)]
 fn verify_batch_proof(c: &mut Criterion) {
     let mut group = c.benchmark_group("verify_batch_proof");
     let mut rng = ChaCha12Rng::seed_from_u64(8675309);

--- a/examples/ringct.rs
+++ b/examples/ringct.rs
@@ -15,7 +15,7 @@ mod test {
     use rand_core::OsRng;
     use triptych::parallel::*;
 
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     #[test]
     fn ringct() {
         // It's important to use a cryptographically-secure random number generator!

--- a/lints.toml
+++ b/lints.toml
@@ -1,6 +1,9 @@
 deny = [
     # Prevent spelling mistakes in lints
     'unknown_lints',
+    
+    # Ensure all expectations are met
+    'unfulfilled_lint_expectations',
 
     # Use the default groups:
     # correctness, suspicious, style, complexity, perf
@@ -24,7 +27,6 @@ deny = [
     'clippy::else_if_without_else',
     'clippy::enum_glob_use',
     'clippy::inline_always',
-    'clippy::match_on_vec_items',
     'clippy::match_wild_err_arm',
 
     # Style preferences

--- a/src/gray.rs
+++ b/src/gray.rs
@@ -7,7 +7,7 @@ use core::num::NonZeroU32;
 use crypto_bigint::{NonZero, U64};
 
 /// An iterator for arbitrary-base Gray codes.
-#[allow(non_snake_case)]
+#[expect(non_snake_case)]
 pub(crate) struct GrayIterator {
     N: u32, // base
     M: u32, // number of digits
@@ -24,7 +24,7 @@ impl GrayIterator {
     ///
     /// Operations using this iterator run in variable time, so don't use this for secret data.
     /// If you need to get the Gray code decomposition for a secret value, use `decompose` directly.
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub(crate) fn new(N: u32, M: u32) -> Option<Self> {
         // Check inputs
         if N <= 1 || M == 0 {
@@ -45,7 +45,7 @@ impl GrayIterator {
     /// You must provide a valid value `v` based on the supplied parameters `N` and `M`.
     /// If anything goes wrong, returns `None`.
     /// Otherwise, returns the Gray code as a `u32` digit vector.
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub(crate) fn decompose_vartime(N: u32, M: u32, mut v: u32) -> Option<Vec<u32>> {
         if N <= 1 || M == 0 {
             return None;
@@ -76,7 +76,7 @@ impl GrayIterator {
     /// You must provide a valid value `v` based on the supplied parameters `N` and `M`.
     /// If anything goes wrong, returns `None`.
     /// Otherwise, returns the Gray code as a `u32` digit vector.
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub(crate) fn decompose(N: u32, M: u32, v: u32) -> Option<Vec<u32>> {
         if N <= 1 || M == 0 {
             return None;
@@ -126,7 +126,6 @@ impl Iterator for GrayIterator {
     ///
     /// Keep in mind that this does not return the actual Gray code!
     /// You must keep track of that yourself.
-    #[allow(non_snake_case)]
     fn next(&mut self) -> Option<Self::Item> {
         if self.i == 0 {
             self.i = 1;
@@ -163,7 +162,7 @@ mod test {
     use super::*;
 
     #[test]
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     fn test_gray_iterator() {
         // Set up parameters
         let N = 3u32;
@@ -195,7 +194,7 @@ mod test {
     }
 
     #[test]
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     fn test_gray_iterator_vartime() {
         // Set up parameters
         let N = 3u32;

--- a/src/parallel/parameters.rs
+++ b/src/parallel/parameters.rs
@@ -21,7 +21,7 @@ use crate::{domains, util::OperationTiming, Transcript};
 /// `G`, `G1`, and `U` required by the protocol. You can either use [`TriptychParameters::new`] to have these generators
 /// defined securely for you, or use [`TriptychParameters::new_with_generators`] if your use case requires specific
 /// values for these.
-#[allow(non_snake_case)]
+#[expect(non_snake_case)]
 #[derive(Clone, Eq, PartialEq)]
 pub struct TriptychParameters {
     n: u32,
@@ -53,7 +53,7 @@ impl TriptychParameters {
     ///
     /// This function produces group generators `G`, `G1` and `U` for you.
     /// If your use case requires specific generators, use [`TriptychParameters::new_with_generators`] instead.
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn new(n: u32, m: u32) -> Result<Self, ParameterError> {
         // Use the default base point for `G` (this is arbitrary)
         let G = RISTRETTO_BASEPOINT_POINT;
@@ -89,7 +89,7 @@ impl TriptychParameters {
     ///
     /// The security of these generators cannot be checked by this function.
     /// If you'd rather have the generators securely defined for you, use [`TriptychParameters::new`] instead.
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn new_with_generators(
         n: u32,
         m: u32,
@@ -199,7 +199,7 @@ impl TriptychParameters {
     /// Get the group generator `G` from these [`TriptychParameters`].
     ///
     /// This is the generator used for defining verification keys.
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn get_G(&self) -> &RistrettoPoint {
         &self.G
     }
@@ -207,7 +207,7 @@ impl TriptychParameters {
     /// Get the group generator `G1` from these [`TriptychParameters`].
     ///
     /// This is the generator used for defining auxiliary verification keys.
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn get_G1(&self) -> &RistrettoPoint {
         &self.G1
     }
@@ -215,7 +215,7 @@ impl TriptychParameters {
     /// Get the group generator `U` from these [`TriptychParameters`].
     ///
     /// This is the generator used for defining linking tags.
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn get_U(&self) -> &RistrettoPoint {
         &self.U
     }
@@ -237,20 +237,20 @@ impl TriptychParameters {
     /// Get the value `N == n**m` from these [`TriptychParameters`].
     ///
     /// This is the verification key vector size.
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn get_N(&self) -> u32 {
         // This is guaranteed not to overflow
         self.n.pow(self.m)
     }
 
     /// Get the value `CommitmentG` from these [`TriptychParameters`].
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub(crate) fn get_CommitmentG(&self) -> &Vec<RistrettoPoint> {
         &self.CommitmentG
     }
 
     /// Get the value `CommitmentH` from these [`TriptychParameters`].
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub(crate) fn get_CommitmentH(&self) -> &RistrettoPoint {
         &self.CommitmentH
     }

--- a/src/parallel/proof.rs
+++ b/src/parallel/proof.rs
@@ -32,7 +32,7 @@ use crate::{
 const SERIALIZED_BYTES: usize = 32;
 
 /// A Triptych proof.
-#[allow(non_snake_case)]
+#[expect(non_snake_case)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TriptychProof {
@@ -168,7 +168,7 @@ impl TriptychProof {
     }
 
     /// The actual prover functionality.
-    #[allow(clippy::too_many_lines, non_snake_case)]
+    #[expect(clippy::too_many_lines, non_snake_case)]
     fn prove_internal<R: CryptoRngCore>(
         witness: &TriptychWitness,
         statement: &TriptychStatement,
@@ -485,7 +485,7 @@ impl TriptychProof {
         let mut right = proofs.len();
 
         while left < right {
-            #[allow(clippy::arithmetic_side_effects)]
+            #[expect(clippy::arithmetic_side_effects)]
             let average = left
                 .checked_add(
                     // This cannot underflow since `left < right`
@@ -493,7 +493,7 @@ impl TriptychProof {
                 )
                 .ok_or(ProofError::FailedBatchVerificationWithSingleBlame { index: None })?;
 
-            #[allow(clippy::arithmetic_side_effects)]
+            #[expect(clippy::arithmetic_side_effects)]
             // This cannot underflow since `left < right`
             let mid = if (right - left) % 2 == 0 {
                 average
@@ -583,7 +583,7 @@ impl TriptychProof {
     /// [`TriptychParameters`](`crate::parameters::TriptychParameters`).
     ///
     /// If any of the above requirements are not met, or if any proof is invalid, returns a [`ProofError`].
-    #[allow(clippy::too_many_lines, non_snake_case)]
+    #[expect(clippy::too_many_lines, non_snake_case)]
     pub fn verify_batch(
         statements: &[TriptychStatement],
         proofs: &[TriptychProof],
@@ -667,7 +667,7 @@ impl TriptychProof {
         })?;
 
         // This is unlikely to overflow; even if it does, the only effect is unnecessary reallocation
-        #[allow(clippy::arithmetic_side_effects)]
+        #[expect(clippy::arithmetic_side_effects)]
         let final_size = usize::try_from(
             1 // G
             + 1 // H
@@ -884,10 +884,10 @@ impl TriptychProof {
     }
 
     /// Serialize a [`TriptychProof`] to a canonical byte vector.
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn to_bytes(&self) -> Vec<u8> {
         // This cannot overflow
-        #[allow(clippy::arithmetic_side_effects)]
+        #[expect(clippy::arithmetic_side_effects)]
         let mut result = Vec::with_capacity(
             8 // `n - 1`, `m`
             + SERIALIZED_BYTES * (
@@ -899,9 +899,9 @@ impl TriptychProof {
                 + self.f.len() * self.f[0].len()
             ),
         );
-        #[allow(clippy::cast_possible_truncation)]
+        #[expect(clippy::cast_possible_truncation)]
         let n_minus_1 = self.f[0].len() as u32;
-        #[allow(clippy::cast_possible_truncation)]
+        #[expect(clippy::cast_possible_truncation)]
         let m = self.f.len() as u32;
         result.extend(n_minus_1.to_le_bytes());
         result.extend(m.to_le_bytes());
@@ -935,7 +935,7 @@ impl TriptychProof {
     /// Deserialize a [`TriptychProof`] from a canonical byte slice.
     ///
     /// If `bytes` does not represent a canonical encoding, returns a [`ProofError`].
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofError> {
         // Helper to parse a `u32` from a `u8` iterator
         let parse_u32 = |iter: &mut dyn Iterator<Item = &u8>| {
@@ -1111,8 +1111,8 @@ mod test {
     }
 
     // Generate a batch of witnesses, statements, and transcripts
-    #[allow(non_snake_case)]
-    #[allow(clippy::arithmetic_side_effects)]
+    #[expect(non_snake_case)]
+    #[expect(clippy::arithmetic_side_effects)]
     fn generate_data<R: CryptoRngCore>(
         n: u32,
         m: u32,
@@ -1173,7 +1173,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "rand")]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_prove_verify() {
         // Generate data
         const n: u32 = 2;
@@ -1187,7 +1187,7 @@ mod test {
     }
 
     #[test]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_prove_verify_with_rng() {
         // Generate data
         const n: u32 = 2;
@@ -1203,7 +1203,7 @@ mod test {
 
     #[test]
     #[cfg(all(feature = "rand", feature = "hazmat"))]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_prove_verify_vartime() {
         // Generate data
         const n: u32 = 2;
@@ -1218,7 +1218,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "hazmat")]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_prove_verify_vartime_with_rng() {
         // Generate data
         const n: u32 = 2;
@@ -1234,7 +1234,7 @@ mod test {
     }
 
     #[test]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_serialize_deserialize() {
         // Generate data
         const n: u32 = 2;
@@ -1257,7 +1257,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "borsh")]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_borsh() {
         // Generate data
         const n: u32 = 2;
@@ -1279,7 +1279,7 @@ mod test {
     }
 
     #[test]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_prove_verify_batch() {
         // Generate data
         const n: u32 = 2;
@@ -1308,7 +1308,7 @@ mod test {
     }
 
     #[test]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_prove_verify_invalid_batch() {
         // Generate data
         const n: u32 = 2;
@@ -1330,7 +1330,7 @@ mod test {
     }
 
     #[test]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_prove_verify_invalid_batch_single_blame() {
         // Generate data
         const n: u32 = 2;
@@ -1364,7 +1364,7 @@ mod test {
     }
 
     #[test]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_prove_verify_invalid_batch_full_blame() {
         // Generate data
         const n: u32 = 2;
@@ -1395,7 +1395,7 @@ mod test {
     }
 
     #[test]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_evil_message() {
         // Generate data
         const n: u32 = 2;
@@ -1415,7 +1415,7 @@ mod test {
     }
 
     #[test]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_snake_case, non_upper_case_globals)]
     fn test_evil_input_set() {
         // Generate data
         const n: u32 = 2;
@@ -1446,7 +1446,7 @@ mod test {
     }
 
     #[test]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_snake_case, non_upper_case_globals)]
     fn test_evil_input_set_auxiliary() {
         // Generate data
         const n: u32 = 2;
@@ -1477,7 +1477,7 @@ mod test {
     }
 
     #[test]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_evil_linking_tag() {
         // Generate data
         const n: u32 = 2;
@@ -1503,7 +1503,7 @@ mod test {
     }
 
     #[test]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_evil_offset() {
         // Generate data
         const n: u32 = 2;

--- a/src/parallel/statement.rs
+++ b/src/parallel/statement.rs
@@ -12,7 +12,7 @@ use crate::{domains, parallel::TriptychParameters, Transcript};
 ///
 /// An input set is constructed from a vector of verification keys and vector of auxiliary verification keys.
 /// Internally, it also contains cryptographic hash data to make proofs more efficient.
-#[allow(non_snake_case)]
+#[expect(non_snake_case)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TriptychInputSet {
     M: Arc<Vec<RistrettoPoint>>,
@@ -23,7 +23,7 @@ pub struct TriptychInputSet {
 impl TriptychInputSet {
     /// Generate a new [`TriptychInputSet`] from a slice `M` of verification keys and slice `M1` of auxiliary
     /// verification keys.
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn new(M: &[RistrettoPoint], M1: &[RistrettoPoint]) -> Result<Self, StatementError> {
         // The verification key vectors must be the same length
         if M.len() != M1.len() {
@@ -44,7 +44,7 @@ impl TriptychInputSet {
     ///
     /// If the verification key vector or auxiliary verification key vector are empty or longer than specified by
     /// `params`, returns a [`StatementError`].
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn new_with_padding(
         M: &[RistrettoPoint],
         M1: &[RistrettoPoint],
@@ -85,7 +85,7 @@ impl TriptychInputSet {
     }
 
     // Helper function to do the actual generation
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     fn new_internal(M: &[RistrettoPoint], M1: &[RistrettoPoint], unpadded_size: usize) -> Result<Self, StatementError> {
         // Ensure the verification key vector lengths don't overflow
         let unpadded_size = u32::try_from(unpadded_size).map_err(|_| StatementError::InvalidParameter {
@@ -133,7 +133,7 @@ impl TriptychInputSet {
 /// The statement consists of an [`TriptychInputSet`] of verification and auxiliary verification keys, an offset, and a
 /// linking tag. It also contains [`TriptychParameters`] that, among other things, enforce the size of the
 /// [`TriptychInputSet`].
-#[allow(non_snake_case)]
+#[expect(non_snake_case)]
 #[derive(Clone, Eq, PartialEq)]
 pub struct TriptychStatement {
     params: TriptychParameters,
@@ -164,7 +164,7 @@ impl TriptychStatement {
     /// The linking tag `J` is assumed to have been computed from
     /// [`TriptychWitness::compute_linking_tag`](`crate::witness::TriptychWitness::compute_linking_tag`) data or
     /// otherwise provided externally.
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn new(
         params: &TriptychParameters,
         input_set: &TriptychInputSet,
@@ -229,7 +229,7 @@ impl TriptychStatement {
     }
 
     /// Get the linking tag for this [`TriptychStatement`].
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn get_J(&self) -> &RistrettoPoint {
         &self.J
     }
@@ -260,7 +260,7 @@ mod test {
     }
 
     #[test]
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     fn test_padding() {
         // Generate parameters
         let params = TriptychParameters::new(2, 4).unwrap();

--- a/src/parallel/transcript.rs
+++ b/src/parallel/transcript.rs
@@ -46,7 +46,7 @@ impl<'a, R: CryptoRngCore> ProofTranscript<'a, R> {
     }
 
     /// Run the Fiat-Shamir commitment phase and produce challenge powers
-    #[allow(non_snake_case, clippy::too_many_arguments)]
+    #[expect(non_snake_case, clippy::too_many_arguments)]
     pub(crate) fn commit(
         &mut self,
         params: &TriptychParameters,
@@ -101,7 +101,7 @@ impl<'a, R: CryptoRngCore> ProofTranscript<'a, R> {
     }
 
     /// Run the Fiat-Shamir response phase
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub(crate) fn response(
         mut self,
         f: &Vec<Vec<Scalar>>,

--- a/src/parallel/witness.rs
+++ b/src/parallel/witness.rs
@@ -40,7 +40,6 @@ impl TriptychWitness {
     /// [`TriptychParameters`] `params`. If any of these conditions is not met, returns a [`WitnessError`].
     ///
     /// If you'd like a [`TriptychWitness`] generated securely for you, use [`TriptychWitness::random`] instead.
-    #[allow(non_snake_case)]
     pub fn new(params: &TriptychParameters, l: u32, r: &Scalar, r1: &Scalar) -> Result<Self, WitnessError> {
         if r == &Scalar::ZERO {
             return Err(WitnessError::InvalidParameter { reason: "`r == 0`" });
@@ -66,12 +65,12 @@ impl TriptychWitness {
     /// This will generate a [`TriptychWitness`] with a cryptographically-secure signing key and random index.
     ///
     /// If you'd rather provide your own secret data, use [`TriptychWitness::new`] instead.
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     pub fn random<R: CryptoRngCore>(params: &TriptychParameters, rng: &mut R) -> Self {
         // Generate a random index using wide reduction
         // This can't truncate since `N` is bounded by `u32`
         // It is also defined since `N > 0`
-        #[allow(clippy::arithmetic_side_effects)]
+        #[expect(clippy::arithmetic_side_effects)]
         let l = (rng.as_rngcore().next_u64() % u64::from(params.get_N())) as u32;
 
         Self {
@@ -103,7 +102,6 @@ impl TriptychWitness {
     }
 
     /// Compute the linking tag for the [`TriptychWitness`] signing key.
-    #[allow(non_snake_case)]
     pub fn compute_linking_tag(&self) -> RistrettoPoint {
         *Zeroizing::new(self.r.invert()) * self.params.get_U()
     }

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -21,7 +21,7 @@ use crate::{domains, util::OperationTiming, Transcript};
 /// `G` and `U` required by the protocol. You can either use [`TriptychParameters::new`] to have these generators
 /// defined securely for you, or use [`TriptychParameters::new_with_generators`] if your use case requires specific
 /// values for these.
-#[allow(non_snake_case)]
+#[expect(non_snake_case)]
 #[derive(Clone, Eq, PartialEq)]
 pub struct TriptychParameters {
     n: u32,
@@ -52,7 +52,7 @@ impl TriptychParameters {
     ///
     /// This function produces group generators `G` and `U` for you.
     /// If your use case requires specific generators, use [`TriptychParameters::new_with_generators`] instead.
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn new(n: u32, m: u32) -> Result<Self, ParameterError> {
         // Use the default base point for `G` (this is arbitrary)
         let G = RISTRETTO_BASEPOINT_POINT;
@@ -79,7 +79,7 @@ impl TriptychParameters {
     ///
     /// The security of these generators cannot be checked by this function.
     /// If you'd rather have the generators securely defined for you, use [`TriptychParameters::new`] instead.
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn new_with_generators(n: u32, m: u32, G: &RistrettoPoint, U: &RistrettoPoint) -> Result<Self, ParameterError> {
         // These bounds are required by the protocol
         if n < 2 {
@@ -181,7 +181,7 @@ impl TriptychParameters {
     /// Get the group generator `G` from these [`TriptychParameters`].
     ///
     /// This is the generator used for defining verification keys.
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn get_G(&self) -> &RistrettoPoint {
         &self.G
     }
@@ -189,7 +189,7 @@ impl TriptychParameters {
     /// Get the group generator `U` from these [`TriptychParameters`].
     ///
     /// This is the generator used for defining linking tags.
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn get_U(&self) -> &RistrettoPoint {
         &self.U
     }
@@ -211,20 +211,20 @@ impl TriptychParameters {
     /// Get the value `N == n**m` from these [`TriptychParameters`].
     ///
     /// This is the verification key vector size.
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn get_N(&self) -> u32 {
         // This is guaranteed not to overflow
         self.n.pow(self.m)
     }
 
     /// Get the value `CommitmentG` from these [`TriptychParameters`].
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub(crate) fn get_CommitmentG(&self) -> &Vec<RistrettoPoint> {
         &self.CommitmentG
     }
 
     /// Get the value `CommitmentH` from these [`TriptychParameters`].
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub(crate) fn get_CommitmentH(&self) -> &RistrettoPoint {
         &self.CommitmentH
     }

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -34,7 +34,7 @@ use crate::{
 const SERIALIZED_BYTES: usize = 32;
 
 /// A Triptych proof.
-#[allow(non_snake_case)]
+#[expect(non_snake_case)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TriptychProof {
@@ -168,7 +168,7 @@ impl TriptychProof {
     }
 
     /// The actual prover functionality.
-    #[allow(clippy::too_many_lines, non_snake_case)]
+    #[expect(clippy::too_many_lines, non_snake_case)]
     fn prove_internal<R: CryptoRngCore>(
         witness: &TriptychWitness,
         statement: &TriptychStatement,
@@ -445,7 +445,7 @@ impl TriptychProof {
         let mut right = proofs.len();
 
         while left < right {
-            #[allow(clippy::arithmetic_side_effects)]
+            #[expect(clippy::arithmetic_side_effects)]
             let average = left
                 .checked_add(
                     // This cannot underflow since `left < right`
@@ -453,7 +453,7 @@ impl TriptychProof {
                 )
                 .ok_or(ProofError::FailedBatchVerificationWithSingleBlame { index: None })?;
 
-            #[allow(clippy::arithmetic_side_effects)]
+            #[expect(clippy::arithmetic_side_effects)]
             // This cannot underflow since `left < right`
             let mid = if (right - left) % 2 == 0 {
                 average
@@ -543,7 +543,7 @@ impl TriptychProof {
     /// [`TriptychParameters`](`crate::parameters::TriptychParameters`).
     ///
     /// If any of the above requirements are not met, or if any proof is invalid, returns a [`ProofError`].
-    #[allow(clippy::too_many_lines, non_snake_case)]
+    #[expect(clippy::too_many_lines, non_snake_case)]
     pub fn verify_batch(
         statements: &[TriptychStatement],
         proofs: &[TriptychProof],
@@ -621,7 +621,7 @@ impl TriptychProof {
         })?;
 
         // This is unlikely to overflow; even if it does, the only effect is unnecessary reallocation
-        #[allow(clippy::arithmetic_side_effects)]
+        #[expect(clippy::arithmetic_side_effects)]
         let final_size = usize::try_from(
             1 // G
             + params.get_n() * params.get_m() // CommitmentG
@@ -810,10 +810,10 @@ impl TriptychProof {
     }
 
     /// Serialize a [`TriptychProof`] to a canonical byte vector.
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn to_bytes(&self) -> Vec<u8> {
         // This cannot overflow
-        #[allow(clippy::arithmetic_side_effects)]
+        #[expect(clippy::arithmetic_side_effects)]
         let mut result = Vec::with_capacity(
             8 // `n - 1`, `m`
             + SERIALIZED_BYTES * (
@@ -824,9 +824,9 @@ impl TriptychProof {
                 + self.f.len() * self.f[0].len()
             ),
         );
-        #[allow(clippy::cast_possible_truncation)]
+        #[expect(clippy::cast_possible_truncation)]
         let n_minus_1 = self.f[0].len() as u32;
-        #[allow(clippy::cast_possible_truncation)]
+        #[expect(clippy::cast_possible_truncation)]
         let m = self.f.len() as u32;
         result.extend(n_minus_1.to_le_bytes());
         result.extend(m.to_le_bytes());
@@ -856,7 +856,7 @@ impl TriptychProof {
     /// Deserialize a [`TriptychProof`] from a canonical byte slice.
     ///
     /// If `bytes` does not represent a canonical encoding, returns a [`ProofError`].
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProofError> {
         // Helper to parse a `u32` from a `u8` iterator
         let parse_u32 = |iter: &mut dyn Iterator<Item = &u8>| {
@@ -1024,8 +1024,8 @@ mod test {
     }
 
     // Generate a batch of witnesses, statements, and transcripts
-    #[allow(non_snake_case)]
-    #[allow(clippy::arithmetic_side_effects)]
+    #[expect(non_snake_case)]
+    #[expect(clippy::arithmetic_side_effects)]
     fn generate_data<R: CryptoRngCore>(
         n: u32,
         m: u32,
@@ -1077,7 +1077,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "rand")]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_prove_verify() {
         // Generate data
         const n: u32 = 2;
@@ -1091,7 +1091,7 @@ mod test {
     }
 
     #[test]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_prove_verify_with_rng() {
         // Generate data
         const n: u32 = 2;
@@ -1107,7 +1107,7 @@ mod test {
 
     #[test]
     #[cfg(all(feature = "rand", feature = "hazmat"))]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_prove_verify_vartime() {
         // Generate data
         const n: u32 = 2;
@@ -1122,7 +1122,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "hazmat")]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_prove_verify_vartime_with_rng() {
         // Generate data
         const n: u32 = 2;
@@ -1138,7 +1138,7 @@ mod test {
     }
 
     #[test]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_serialize_deserialize() {
         // Generate data
         const n: u32 = 2;
@@ -1161,7 +1161,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "borsh")]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_borsh() {
         // Generate data
         const n: u32 = 2;
@@ -1183,7 +1183,7 @@ mod test {
     }
 
     #[test]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_prove_verify_batch() {
         // Generate data
         const n: u32 = 2;
@@ -1212,7 +1212,7 @@ mod test {
     }
 
     #[test]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_prove_verify_invalid_batch() {
         // Generate data
         const n: u32 = 2;
@@ -1234,7 +1234,7 @@ mod test {
     }
 
     #[test]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_prove_verify_invalid_batch_single_blame() {
         // Generate data
         const n: u32 = 2;
@@ -1268,7 +1268,7 @@ mod test {
     }
 
     #[test]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_prove_verify_invalid_batch_full_blame() {
         // Generate data
         const n: u32 = 2;
@@ -1299,7 +1299,7 @@ mod test {
     }
 
     #[test]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_evil_message() {
         // Generate data
         const n: u32 = 2;
@@ -1319,7 +1319,7 @@ mod test {
     }
 
     #[test]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_snake_case, non_upper_case_globals)]
     fn test_evil_input_set() {
         // Generate data
         const n: u32 = 2;
@@ -1344,7 +1344,7 @@ mod test {
     }
 
     #[test]
-    #[allow(non_snake_case, non_upper_case_globals)]
+    #[expect(non_upper_case_globals)]
     fn test_evil_linking_tag() {
         // Generate data
         const n: u32 = 2;

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -12,7 +12,7 @@ use crate::{domains, Transcript, TriptychParameters};
 ///
 /// An input set is constructed from a vector of verification keys.
 /// Internally, it also contains cryptographic hash data to make proofs more efficient.
-#[allow(non_snake_case)]
+#[expect(non_snake_case)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TriptychInputSet {
     M: Arc<Vec<RistrettoPoint>>,
@@ -21,7 +21,7 @@ pub struct TriptychInputSet {
 
 impl TriptychInputSet {
     /// Generate a new [`TriptychInputSet`] from a slice `M` of verification keys.
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn new(M: &[RistrettoPoint]) -> Result<Self, StatementError> {
         Self::new_internal(M, M.len())
     }
@@ -33,7 +33,7 @@ impl TriptychInputSet {
     /// element. If your use case cannot safely allow this, use [`TriptychInputSet::new`] instead.
     ///
     /// If the verification key vector is empty or longer than specified by `params`, returns a [`StatementError`].
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn new_with_padding(M: &[RistrettoPoint], params: &TriptychParameters) -> Result<Self, StatementError> {
         // Get the unpadded size
         let unpadded_size = M.len();
@@ -58,7 +58,7 @@ impl TriptychInputSet {
     }
 
     // Helper function to do the actual generation
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     fn new_internal(M: &[RistrettoPoint], unpadded_size: usize) -> Result<Self, StatementError> {
         // Ensure the verification key vector length doesn't overflow
         let unpadded_size = u32::try_from(unpadded_size).map_err(|_| StatementError::InvalidParameter {
@@ -96,7 +96,7 @@ impl TriptychInputSet {
 ///
 /// The statement consists of an [`TriptychInputSet`] of verification keys and a linking tag.
 /// It also contains [`TriptychParameters`] that, among other things, enforce the size of the [`TriptychInputSet`].
-#[allow(non_snake_case)]
+#[expect(non_snake_case)]
 #[derive(Clone, Eq, PartialEq)]
 pub struct TriptychStatement {
     params: TriptychParameters,
@@ -126,7 +126,7 @@ impl TriptychStatement {
     /// The linking tag `J` is assumed to have been computed from
     /// [`TriptychWitness::compute_linking_tag`](`crate::witness::TriptychWitness::compute_linking_tag`) data or
     /// otherwise provided externally.
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn new(
         params: &TriptychParameters,
         input_set: &TriptychInputSet,
@@ -172,7 +172,7 @@ impl TriptychStatement {
     }
 
     /// Get the linking tag for this [`TriptychStatement`].
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub fn get_J(&self) -> &RistrettoPoint {
         &self.J
     }
@@ -203,7 +203,7 @@ mod test {
     }
 
     #[test]
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     fn test_padding() {
         // Generate parameters
         let params = TriptychParameters::new(2, 4).unwrap();

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -42,7 +42,7 @@ impl<'a, R: CryptoRngCore> ProofTranscript<'a, R> {
     }
 
     /// Run the Fiat-Shamir commitment phase and produce challenge powers
-    #[allow(non_snake_case, clippy::too_many_arguments)]
+    #[expect(non_snake_case, clippy::too_many_arguments)]
     pub(crate) fn commit(
         &mut self,
         params: &TriptychParameters,
@@ -93,7 +93,7 @@ impl<'a, R: CryptoRngCore> ProofTranscript<'a, R> {
     }
 
     /// Run the Fiat-Shamir response phase
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     pub(crate) fn response(mut self, f: &Vec<Vec<Scalar>>, z_A: &Scalar, z_C: &Scalar, z: &Scalar) -> TranscriptRng {
         // Update the transcript
         for f_row in f {

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,7 +12,6 @@ use zeroize::Zeroize;
 
 /// Options for constant- or variable-time operations.
 #[derive(Clone, Copy)]
-#[allow(dead_code)]
 pub(crate) enum OperationTiming {
     /// The operation should attempt to run in constant time
     Constant,

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -39,7 +39,6 @@ impl TriptychWitness {
     /// If any of these conditions is not met, returns a [`WitnessError`].
     ///
     /// If you'd like a [`TriptychWitness`] generated securely for you, use [`TriptychWitness::random`] instead.
-    #[allow(non_snake_case)]
     pub fn new(params: &TriptychParameters, l: u32, r: &Scalar) -> Result<Self, WitnessError> {
         if r == &Scalar::ZERO {
             return Err(WitnessError::InvalidParameter { reason: "`r == 0`" });
@@ -61,12 +60,12 @@ impl TriptychWitness {
     /// This will generate a [`TriptychWitness`] with a cryptographically-secure signing key and random index.
     ///
     /// If you'd rather provide your own secret data, use [`TriptychWitness::new`] instead.
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     pub fn random<R: CryptoRngCore>(params: &TriptychParameters, rng: &mut R) -> Self {
         // Generate a random index using wide reduction
         // This can't truncate since `N` is bounded by `u32`
         // It is also defined since `N > 0`
-        #[allow(clippy::arithmetic_side_effects)]
+        #[expect(clippy::arithmetic_side_effects)]
         let l = (rng.as_rngcore().next_u64() % u64::from(params.get_N())) as u32;
 
         Self {
@@ -92,7 +91,6 @@ impl TriptychWitness {
     }
 
     /// Compute the linking tag for the [`TriptychWitness`] signing key.
-    #[allow(non_snake_case)]
     pub fn compute_linking_tag(&self) -> RistrettoPoint {
         *Zeroizing::new(self.r.invert()) * self.params.get_U()
     }


### PR DESCRIPTION
This PR moves lint exceptions from `allow` to `expect` to keep things cleaner and more maintainable. Alongside this change, CI is updated to fail on unused exceptions, and a nonexistent lint is removed from the configuration.

Closes #112.